### PR TITLE
repo: Change to dora-metrics organization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,4 @@ related to #<!-- issue number -->
 
 ## Testing Instructions
 
-Please include any additional commands or pointers in addition to our [standard PR testing process](https://pelorus.readthedocs.io/en/latest/Development/#testing-pull-requests).
-
-@redhat-cop/mdt
+<!-- Please include any additional commands or pointers in addition to our [standard PR testing process](https://pelorus.readthedocs.io/en/latest/Development/#testing-pull-requests) -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ Here is a link to the General Contribution Guidelines for the Red Hat Communitie
 [Contribution Guidelines](https://redhat-cop.github.io/contrib/)
 
 If you’d like to contribute, start by searching through the GitHub
-[issues](https://github.com/konveyor/pelorus/issues) and
-[pull requests](https://github.com/konveyor/pelorus/pulls) to see
+[issues](https://github.com/dora-metrics/pelorus/issues) and
+[pull requests](https://github.com/dora-metrics/pelorus/pulls) to see
 whether someone else has raised a similar idea or question.
 
 If you don’t see your idea listed, and you think it fits into the goals

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![Pelorus](docs/img/Logo-Pelorus-A-Standard-RGB_smaller.png)
 
-![](https://github.com/redhat-cop/pelorus/workflows/Pylama/badge.svg)
-![](https://github.com/redhat-cop/pelorus/workflows/Unit%20Tests/badge.svg)
-![](https://github.com/redhat-cop/pelorus/workflows/Conftest/badge.svg)
-![](https://github.com/redhat-cop/pelorus/workflows/Chart%20Lint/badge.svg)
+[![Python Linting](https://github.com/dora-metrics/pelorus/actions/workflows/python-linting.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
+[![Unit tests](https://github.com/dora-metrics/pelorus/actions/workflows/unittests.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
+[![Conftest](https://github.com/dora-metrics/pelorus/actions/workflows/conftest.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
+[![Chart Lint](https://github.com/dora-metrics/pelorus/actions/workflows/chart-lint.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
@@ -39,7 +39,7 @@ If you are interested in contributing to the Pelorus project, please review our 
 Our support policy can be found in the [Upstream Support statement](docs/UpstreamSupport.md)
 
 ## Code of Conduct
-Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).
+Refer to dora-metrics's Code of Conduct [here](https://github.com/dora-metrics/community/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are interested in contributing to the Pelorus project, please review our 
 Our support policy can be found in the [Upstream Support statement](docs/UpstreamSupport.md)
 
 ## Code of Conduct
-Refer to dora-metrics's Code of Conduct [here](https://github.com/dora-metrics/community/blob/main/CODE_OF_CONDUCT.md).
+Refer to dora-metrics's Code of Conduct [here](./CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -18,7 +18,7 @@ spec:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
       ref: {{ .source_ref | default "v2.0.8" }}
-      uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
+      uri: {{ .source_url | default "https://github.com/dora-metrics/pelorus.git"}}
     type: Git
   strategy:
     sourceStrategy:

--- a/charts/pelorus/subcharts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_deploymentconfig.yaml
@@ -23,7 +23,7 @@ spec:
         app: {{ .app_name }}
         deploymentconfig: {{ .app_name }}
         application: {{ .app_name }}
-        pelorus.konveyor.io/exporter-type: {{ .exporter_type | default "generic-exporter" }}
+        pelorus.dora-metrics.io/exporter-type: {{ .exporter_type | default "generic-exporter" }}
     spec:
       serviceAccount: pelorus-exporter
       volumes:

--- a/demo/README.md
+++ b/demo/README.md
@@ -10,7 +10,7 @@ The details of each build type and the steps required to support Pelorus can be 
 
 * Install the Pelorus operator, using the installation [documentation](../docs/GettingStarted/Installation.md)
 
-* Fork the [konveyor/pelorus](https://github.com/konveyor/pelorus) git repository to your github organization.
+* Fork the [dora-metrics/pelorus](https://github.com/dora-metrics/pelorus) git repository to your github organization.
 
 * Add or configure your github-secret with your Github token:
 ```

--- a/demo/demo-tekton.sh
+++ b/demo/demo-tekton.sh
@@ -130,7 +130,7 @@ fi
 # FOUND_COMMITTIME=false
 # Check if Pelorus is deployed on the cluster and monitors
 # required namespace or default one, which means all of them
-# COMMITTIME_EXPORTERS=$(oc get pod -n pelorus -l pelorus.konveyor.io/exporter-type=committime --field-selector=status.phase==Running --no-headers -o custom-columns=":metadata.name")
+# COMMITTIME_EXPORTERS=$(oc get pod -n pelorus -l pelorus.dora-metrics.io/exporter-type=committime --field-selector=status.phase==Running --no-headers -o custom-columns=":metadata.name")
 # for committime_exporter in $COMMITTIME_EXPORTERS;
 # do
 #  committime_namespaces=$(oc exec -n pelorus "${committime_exporter}" -- printenv NAMESPACES)

--- a/demo/tekton-demo-setup/05-build-and-deploy.yaml
+++ b/demo/tekton-demo-setup/05-build-and-deploy.yaml
@@ -11,7 +11,7 @@ parameters:
     value: basic-python-tekton
   - name: PROJECT_URI
     description: "Project URI with the python-demo"
-    value: https://github.com/konveyor/pelorus
+    value: https://github.com/dora-metrics/pelorus
   - name: PROJECT_REF
     description: "Project ref with the python-demo"
     value: master

--- a/demo/tekton-demo-setup/operator_tekton_demo_values.yaml.sample
+++ b/demo/tekton-demo-setup/operator_tekton_demo_values.yaml.sample
@@ -1,5 +1,5 @@
 kind: Pelorus
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 metadata:
   name: pelorus-sample
   namespace: pelorus

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -15,7 +15,7 @@ This track is focused around the development of custom [Prometheus exporters](ht
 
 Architectural Decision Records (ADRs) let us keep a record of the development choices we made, the context of the problem, and why we picked the solution we did.
 
-Our ADRs are kept in the [ADRs directory](https://github.com/konveyor/pelorus/tree/master/docs/adr/) following the [agreed upon format](./adr/0001-record-architecture-decisions.md).
+Our ADRs are kept in the [ADRs directory](https://github.com/dora-metrics/pelorus/tree/master/docs/adr/) following the [agreed upon format](./adr/0001-record-architecture-decisions.md).
 
 ### ADR template
 
@@ -81,15 +81,15 @@ See the [Install guide](GettingStarted/Installation.md) for more details on that
 
 Currently we have two charts:
 
-1. The [operators](https://github.com/konveyor/pelorus/blob/master/charts/operators/) chart installs the community operators on which Pelorus depends.
+1. The [operators](https://github.com/dora-metrics/pelorus/blob/master/charts/operators/) chart installs the community operators on which Pelorus depends.
     * [Prometheus Operator](https://operatorhub.io/operator/prometheus)
     * [Grafana Operator](https://operatorhub.io/operator/grafana-operator)
-2. The [pelorus](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/) chart manages the Pelorus stack, which includes:
+2. The [pelorus](https://github.com/dora-metrics/pelorus/blob/master/charts/pelorus/) chart manages the Pelorus stack, which includes:
     * Prometheus
     * Thanos
     * Grafana
     * A set of Grafana Dashboards and Datasources
-    * The Pelorus exporters, managed in an [exporter](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/charts/exporters) subchart.
+    * The Pelorus exporters, managed in an [exporter](https://github.com/dora-metrics/pelorus/blob/master/charts/pelorus/charts/exporters) subchart.
 
 We use Helm's [chart-testing](https://github.com/helm/chart-testing) tool to ensure quality and consistency in the chart. When making updates to one of the charts, ensure that the chart still passes lint testing using `make chart-lint`. The most common linting failure is forgetting to bump the `version` field in the `Chart.yaml`. See below for instructions on updating the version.
 
@@ -104,7 +104,7 @@ We have provided scripts that can test when a version bump is needed and do the 
 
 You can check all chart versions and bump them if needed with a script that compares upstream pelorus repository with the changes in a fork. To do so ensure your upstream repository is added to your fork by:
 
-    $ git remote add upstream https://github.com/konveyor/pelorus.git
+    $ git remote add upstream https://github.com/dora-metrics/pelorus.git
     $ git pull
     $ make chart-check-bump
 
@@ -216,9 +216,9 @@ If not defined specifically, exporters are using pre-built container images with
 
 #### Pre-built Quay images
 
-Each Pelorus GitHub pull request that is [merged](https://github.com/konveyor/pelorus/pulls?q=is%3Apr+is%3Amerged) results in a new set of images that are tagged with the GitHub commit hash, for example `d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31` for the following [Pull Request](https://github.com/konveyor/pelorus/commit/d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31). The newest merged commit results in additional image tag `latest`.
+Each Pelorus GitHub pull request that is [merged](https://github.com/dora-metrics/pelorus/pulls?q=is%3Apr+is%3Amerged) results in a new set of images that are tagged with the GitHub commit hash, for example `d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31` for the following [Pull Request](https://github.com/dora-metrics/pelorus/commit/d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31). The newest merged commit results in additional image tag `latest`.
 
-Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.8`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
+Each new Pelorus [release](https://github.com/dora-metrics/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.8`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
 
 During Pelorus Helm deployment or update time user have option to specify the image tag for each exporter instance individually. Example below shows two different tags for the commit time exporter and two tags for the failure exporter.
 
@@ -302,7 +302,7 @@ exporters:
 
 #### Source-to-image (S2I)
 
-By specifying `source_url` and optionally `source_ref` Pelorus exporters will use installation method that performs incremental builds of the exporter images using source from the GIT repository. Images are being stored in an OpenShift Container Platform registry and used during Pelorus Helm deployment or update. Each instance that uses this method results in a new build. This method is recommended for development or unmerged bug-fixes as it may point to any GIT and any branch or GIT reference. By default `source_ref` points to the latest [released](https://github.com/konveyor/pelorus/releases) Pelorus.
+By specifying `source_url` and optionally `source_ref` Pelorus exporters will use installation method that performs incremental builds of the exporter images using source from the GIT repository. Images are being stored in an OpenShift Container Platform registry and used during Pelorus Helm deployment or update. Each instance that uses this method results in a new build. This method is recommended for development or unmerged bug-fixes as it may point to any GIT and any branch or GIT reference. By default `source_ref` points to the latest [released](https://github.com/dora-metrics/pelorus/releases) Pelorus.
 
 Example of such exporter instances are below:
 
@@ -311,7 +311,7 @@ exporters:
   instances:
   - app_name: committime-github
     exporter_type: comittime
-    source_url: https://github.com/konveyor/pelorus.git
+    source_url: https://github.com/dora-metrics/pelorus.git
     source_ref: refs/pull/567/head # References not merged GitHub pull request number 567
     env_from_secrets:
     - github-credentials
@@ -364,7 +364,7 @@ pre-commit run --all-files
 
 To bypass pre-commit checks, pass the `--no-verify` (`-n`) flag to `git commit` command.
 
-pre-commit configuration in [`.pre-commit-config.yaml`](https://github.com/konveyor/pelorus/blob/master/.pre-commit-config.yaml) file.
+pre-commit configuration in [`.pre-commit-config.yaml`](https://github.com/dora-metrics/pelorus/blob/master/.pre-commit-config.yaml) file.
 
 #### IDE Setup (VSCode)
 
@@ -491,7 +491,7 @@ The following are notes and general steps for testing Pull Requests for specific
 
 To checkout PR we recommend using [GitHub CLI](https://cli.github.com/), which simplifies process of pulling PRs.
 
-Ensure you have [Pelorus](https://github.com/konveyor/pelorus) GitHub project Forked into your GitHub user space.
+Ensure you have [Pelorus](https://github.com/dora-metrics/pelorus) GitHub project Forked into your GitHub user space.
 
 #### <a id="checkout"></a>
 Checkout the PR on top of your fork.
@@ -502,7 +502,7 @@ Checkout the PR on top of your fork.
 
     # If asked:
     # ? Which should be the base repository, select:
-    # > konveyor/pelorus
+    # > dora-metrics/pelorus
 
 
 ### Dashboard Changes
@@ -592,7 +592,7 @@ Pelorus release versions follow SemVer versioning conventions. Change of the ver
 
 2. Propose Pull Request to the project github repository. Ensure that the PR is labeled with "minor" or "major" if one was created.
 
-3. After PR is merged on the [Pelorus releases](https://github.com/konveyor/pelorus/releases) page, click edit on the latest **Draft**.
+3. After PR is merged on the [Pelorus releases](https://github.com/dora-metrics/pelorus/releases) page, click edit on the latest **Draft**.
     * Click **Publish Release**.
 
 ## Testing the Docs
@@ -611,7 +611,7 @@ rm -rf .cache && mkdocs serve
 ```
 to fix it.
 
-The mkdocs config is controlled by the `mkdocs.yml` file in the root of this project. All of the documents that will be served are in the [/docs](https://github.com/konveyor/pelorus/tree/master/docs) folder.
+The mkdocs config is controlled by the `mkdocs.yml` file in the root of this project. All of the documents that will be served are in the [/docs](https://github.com/dora-metrics/pelorus/tree/master/docs) folder.
 
 To generate diagrams images, run
 ```

--- a/docs/GettingStarted/Examples.md
+++ b/docs/GettingStarted/Examples.md
@@ -22,7 +22,7 @@ In this example, Pelorus will monitor only one application, where:
     * Pelorus will consider monitored issues to be resolved when their status change to **DONE**.
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: bitbucket-jira-example-configuration
@@ -86,7 +86,7 @@ In this example, Pelorus will monitor only one application, where:
     * Pelorus will consider monitored issues to be resolved when they are closed.
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: github-example-configuration
@@ -150,7 +150,7 @@ In this example, Pelorus will monitor two applications, where:
     * Pelorus will consider monitored issues to be resolved when their status change to **DONE**.
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: github-bitbucket-jira-example-configuration
@@ -202,7 +202,7 @@ spec:
 In this example, Pelorus will receive data from the external systems without making any API calls to OpenShift nor external providers.
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: webhook-example-deployment

--- a/docs/GettingStarted/Installation.md
+++ b/docs/GettingStarted/Installation.md
@@ -145,7 +145,7 @@ See the [Pelorus Exporters Configuration Guide](configuration/PelorusExporters.m
   ```shell
   $ cat > pelorus-sample-instance.yaml <<EOF
   kind: Pelorus
-  apiVersion: charts.pelorus.konveyor.io/v1alpha1
+  apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
   metadata:
     name: pelorus-sample
     namespace: pelorus
@@ -292,15 +292,15 @@ When Pelorus gets installed via helm charts, the first deploys the operators on 
 
 To begin, clone Pelorus repository. To do so, you can run
 ```
-git clone https://github.com/konveyor/pelorus.git
+git clone https://github.com/dora-metrics/pelorus.git
 ```
 which will download the latest code of Pelorus.
 
 To download a stable version, run
 ```
-git clone --depth 1 --branch <TAG> https://github.com/konveyor/pelorus.git
+git clone --depth 1 --branch <TAG> https://github.com/dora-metrics/pelorus.git
 ```
-changing **TAG** by one of [Pelorus versions](https://github.com/konveyor/pelorus/tags).
+changing **TAG** by one of [Pelorus versions](https://github.com/dora-metrics/pelorus/tags).
 
 Change the current directory to `pelorus`, by running
 ```

--- a/docs/GettingStarted/Overview.md
+++ b/docs/GettingStarted/Overview.md
@@ -30,7 +30,7 @@ Pelorus is composed of Prometheus, Grafana and exporters. It can be easily deplo
 
 List of providers supported by Pelorus.
 
-Open an [issue](https://github.com/konveyor/pelorus/issues/new) or a pull request to add support for additional providers!
+Open an [issue](https://github.com/dora-metrics/pelorus/issues/new) or a pull request to add support for additional providers!
 
 ### Deployment
 

--- a/docs/GettingStarted/QuickstartTutorial.md
+++ b/docs/GettingStarted/QuickstartTutorial.md
@@ -68,7 +68,7 @@ For this demo we will need to prepare a configuration file that will be used in 
 Let's create the Pelorus Configuration file and save it under the `pelorus-quickstart.yaml` file. Please adjust the `<your_github_api_token>` and `<your_org>`:
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: pelorus-quickstart

--- a/docs/GettingStarted/configuration/ExporterCommittime.md
+++ b/docs/GettingStarted/configuration/ExporterCommittime.md
@@ -39,7 +39,7 @@ Pelorus configuration object YAML file with three `committime` exporters:
   - Third exporter is using [image](#using-commit-time-with-images) to gather commit date which was used for the deployment directly from the Image annotation `myapp.build.commit.date` that uses date format `%a %b %d %H:%M:%S %Y %z`. This annotation has to be provided by 3rd party systems such as different flavour CI systems. This exporter does not query any external API endpoint.
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: sample-pelorus-deployment
@@ -287,14 +287,14 @@ oc start-build "bc/${NAME}" --from-file=./app.py --follow -n "${NS}"
 oc get builds -n "${NS}"
 oc -n "${NS}" annotate build "${NAME}-1" --overwrite \
 io.openshift.build.commit.id=7810f2a85d5c89cb4b17e9a3208a311af65338d8 \
-io.openshift.build.source-location=http://github.com/konveyor/pelorus
+io.openshift.build.source-location=http://github.com/dora-metrics/pelorus
 
 oc -n "${NS}" new-app "${NAME}" -l "app.kubernetes.io/name=${NAME}"
 ```
 
 ### Additional Examples
 
-There are many ways to build and deploy applications in OpenShift. Additional examples of how to annotate builds such that Pelorus will properly discover the commit metadata can be found in the  [Pelorus tekton demo](https://github.com/konveyor/pelorus/tree/master/demo)
+There are many ways to build and deploy applications in OpenShift. Additional examples of how to annotate builds such that Pelorus will properly discover the commit metadata can be found in the  [Pelorus tekton demo](https://github.com/dora-metrics/pelorus/tree/master/demo)
 
 ## Annotations, Docker Labels and Image support
 

--- a/docs/GettingStarted/configuration/ExporterDeploytime.md
+++ b/docs/GettingStarted/configuration/ExporterDeploytime.md
@@ -18,7 +18,7 @@ Pelorus configuration object YAML file with three exporters, each typeof `deploy
   ```
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: sample-pelorus-deployment

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -7,7 +7,7 @@ Failure Time Exporter may be deployed with one of the [supported Issues Trackers
 Each Failure time exporter configuration option must be placed under `spec.exporters.instances` in the Pelorus configuration object YAML file as in the example:
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: example-configuration
@@ -24,7 +24,7 @@ spec:
 Configuration part of the Failure time exporter YAML file, with some non-default options:
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: example-configuration

--- a/docs/GettingStarted/configuration/ExporterWebhook.md
+++ b/docs/GettingStarted/configuration/ExporterWebhook.md
@@ -15,7 +15,7 @@ It's important to note that the webhook exporter performs validation of the payl
 The webhook exporter configuration option must be placed under `spec.exporters.instances` in the Pelorus configuration object YAML file as in the example, with a non-default [LOG_LEVEL](#log_level) option:
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: example-configuration

--- a/docs/GettingStarted/configuration/PelorusCore.md
+++ b/docs/GettingStarted/configuration/PelorusCore.md
@@ -8,7 +8,7 @@ Each Pelorus Core configuration option must be placed under `spec` in the Peloru
 
 ```yaml
 kind: Pelorus
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 metadata:
   name: pelorus-pelorus-instance
   namespace: pelorus
@@ -26,7 +26,7 @@ Configuration part of the Pelorus object YAML file, with some non-default option
 
 ```yaml
 kind: Pelorus
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 metadata:
   name: pelorus-instance
   namespace: pelorus

--- a/docs/GettingStarted/configuration/PelorusExporters.md
+++ b/docs/GettingStarted/configuration/PelorusExporters.md
@@ -11,7 +11,7 @@ There are currently four **exporter** types:
 Each exporter configuration option must be placed under `spec.exporters.instances` in the Pelorus configuration object YAML file as in the example:
 
 ```yaml
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 kind: Pelorus
 metadata:
   name: example-configuration
@@ -28,7 +28,7 @@ Configuration part of the Pelorus object YAML file, with some non-default option
 
 ```yaml
 kind: Pelorus
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 metadata:
   name: pelorus-instance
   namespace: pelorus
@@ -235,7 +235,7 @@ Then, add
         - example-secret
 [...]
 ```
-to the exporter configuration. If no `metadata.namespace` is added to Secret file, you must run the command with the namespace you want to apply it. For example, `oc apply -f secret.yaml -n pelorus`. More [examples Secret files](https://github.com/konveyor/pelorus/tree/master/charts/secrets).
+to the exporter configuration. If no `metadata.namespace` is added to Secret file, you must run the command with the namespace you want to apply it. For example, `oc apply -f secret.yaml -n pelorus`. More [examples Secret files](https://github.com/dora-metrics/pelorus/tree/master/charts/secrets).
 
 1. To create a secret named **other-secret** in **pelorus** namespace, with the
 
@@ -286,7 +286,7 @@ Then, add
         - example-config
 [...]
 ```
-to the exporter configuration. If no `metadata.namespace` is added to ConfigMap file, you must run the command with the namespace you want to apply it. For example, `oc apply -f config.yaml -n pelorus`. More [examples ConfigMap files](https://github.com/konveyor/pelorus/tree/master/charts/configmaps).
+to the exporter configuration. If no `metadata.namespace` is added to ConfigMap file, you must run the command with the namespace you want to apply it. For example, `oc apply -f config.yaml -n pelorus`. More [examples ConfigMap files](https://github.com/dora-metrics/pelorus/tree/master/charts/configmaps).
 
 1. To create a ConfigMap named **example-for-all** in **pelorus** namespace, that will be used by multiple exporters, with the option **LOG_LEVEL** with value **DEBUG**, using the file **config.yaml**
 ```yaml

--- a/docs/GettingStarted/configuration/ProductionBestPractice.md
+++ b/docs/GettingStarted/configuration/ProductionBestPractice.md
@@ -47,7 +47,7 @@ A production configuration example of the Pelorus configuration object YAML:
 
 ```yaml
 kind: Pelorus
-apiVersion: charts.pelorus.konveyor.io/v1alpha1
+apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
 metadata:
   name: pelorus-production
   namespace: pelorus

--- a/docs/UpstreamSupport.md
+++ b/docs/UpstreamSupport.md
@@ -1,12 +1,12 @@
 # Pelorus Upstream Support Statement
 
-The Pelorus engineering team will provide `best-effort` level support for Pelorus on the currently latest and the latest previous released versions of Openshift.  More specifically if the latest released version of Openshift is `4.11`, the engineering team will accept [issues](https://github.com/konveyor/pelorus/issues) written for OpenShift `4.11` and `4.10`.
+The Pelorus engineering team will provide `best-effort` level support for Pelorus on the currently latest and the latest previous released versions of Openshift.  More specifically if the latest released version of Openshift is `4.11`, the engineering team will accept [issues](https://github.com/dora-metrics/pelorus/issues) written for OpenShift `4.11` and `4.10`.
 
-* To file a bug please create a [Github issue](https://github.com/konveyor/pelorus/issues) with the label "kind/bug"
+* To file a bug please create a [Github issue](https://github.com/dora-metrics/pelorus/issues) with the label "kind/bug"
 
-* To file a feature request create a [Github issue](https://github.com/konveyor/pelorus/issues) with the label "kind/feature"
+* To file a feature request create a [Github issue](https://github.com/dora-metrics/pelorus/issues) with the label "kind/feature"
 
-* You may also consider opening a [discussion](https://github.com/konveyor/pelorus/discussions) thread to discuss any feature, bug, or enhancement prior to opening a Github issue.
+* You may also consider opening a [discussion](https://github.com/dora-metrics/pelorus/discussions) thread to discuss any feature, bug, or enhancement prior to opening a Github issue.
 
 ## Backend Exporters
 
@@ -19,44 +19,44 @@ with out CI integration will have an associated Github issue in CI status and St
 
 |Backend |Known issues        |CI status    |
 |:--------|:--------------|:-------------|
-| GitHub  | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-github)   | [Integration CI present](#integration-in-ci) |
-| GitHub Enterprise | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-github-enterprise+) |  [todo](https://github.com/konveyor/pelorus/issues/561) |
-| Bitbucket | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-bitbucket+) | [Integration CI present](#integration-in-ci) |
-| Gitlab | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-gitlab) | [Integration CI present](#integration-in-ci) |
-| Gitea | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-gitea) | [Integration CI present](#integration-in-ci) |
-| Azure DevOps | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-azure-devops) | [todo](https://github.com/konveyor/pelorus/issues/569) |
+| GitHub  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-github)   | [Integration CI present](#integration-in-ci) |
+| GitHub Enterprise | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-github-enterprise+) |  [todo](https://github.com/dora-metrics/pelorus/issues/561) |
+| Bitbucket | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-bitbucket+) | [Integration CI present](#integration-in-ci) |
+| Gitlab | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-gitlab) | [Integration CI present](#integration-in-ci) |
+| Gitea | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-gitea) | [Integration CI present](#integration-in-ci) |
+| Azure DevOps | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Acommittime-exporter+label%3Abackend-azure-devops) | [todo](https://github.com/dora-metrics/pelorus/issues/569) |
 
 ### **Failure Exporter**
 
 |Backend |Known issues        |CI status    |
 |:--------|:--------------|:-------------|
-| Jira  | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-jira+ )   | [Integration CI present](#integration-in-ci) |
-| GitHub  | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-github+)   | [Integration CI present](#integration-in-ci) |
-| Service Now | [status link](https://github.com/konveyor/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-servicenow+) | [todo](https://github.com/konveyor/pelorus/issues/573) 
+| Jira  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-jira+ )   | [Integration CI present](#integration-in-ci) |
+| GitHub  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-github+)   | [Integration CI present](#integration-in-ci) |
+| Service Now | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-servicenow+) | [todo](https://github.com/dora-metrics/pelorus/issues/573)
 
 ### **Deploytime Exporter**
 |Backend |Known issues        |CI status    |
 |:--------|:--------------|:-------------|
-| OpenShift  | [status link](https://github.com/konveyor/pelorus/labels/deploytime-exporter)   | [Integration CI present](#integration-in-ci) |
+| OpenShift  | [status link](https://github.com/dora-metrics/pelorus/labels/deploytime-exporter)   | [Integration CI present](#integration-in-ci) |
 
 ## Integration in CI
 Pelorus is being tested and it's parts such as container images or documentation are being created by various Continuous Integration systems.
 
-Most of the CI runs are invoked using [Makefile](https://github.com/konveyor/pelorus/blob/master/Makefile) allowing developer to replicate those runs on the local computer. Please refer to the [Dev Guide](Development.md) for more information.
+Most of the CI runs are invoked using [Makefile](https://github.com/dora-metrics/pelorus/blob/master/Makefile) allowing developer to replicate those runs on the local computer. Please refer to the [Dev Guide](Development.md) for more information.
 
 ### GitHub Actions
 
-Each Pull Request is being tested by various GitHub Actions corresponding to the files being modified or triggers such as new release. List of all GitHub Actions enabled for Pelorus can be found in the [.github](https://github.com/konveyor/pelorus/tree/master/.github) folder of the project.
+Each Pull Request is being tested by various GitHub Actions corresponding to the files being modified or triggers such as new release. List of all GitHub Actions enabled for Pelorus can be found in the [.github](https://github.com/dora-metrics/pelorus/tree/master/.github) folder of the project.
 
 ### Prow OpenShift CI
 
 Number of [Pelorus jobs](https://prow.ci.openshift.org/?job=*pelorus*) are running in dedicated Prow OpenShift CI, which is integrated with GitHub project. Triggers for those jobs are either new GitHub Pull Requests or periodic events.
 
-Similarly to the [GitHub Actions](#github-actions) those jobs uses [Makefile](https://github.com/konveyor/pelorus/blob/master/Makefile) as the entry point for execution.
+Similarly to the [GitHub Actions](#github-actions) those jobs uses [Makefile](https://github.com/dora-metrics/pelorus/blob/master/Makefile) as the entry point for execution.
 
-E2E Pull Request jobs consumes Pelorus deployment files, which are defined in the [mig-demo-apps values.yaml](https://github.com/konveyor/mig-demo-apps/blob/master/apps/todolist-mongo-go/pelorus/values.yaml) project and requires secrets that are configured using [vault.ci.openshift.org](https://vault.ci.openshift.org). Those secrets are then mounted by the [Prow job definition](https://github.com/openshift/release/blob/master/ci-operator/config/konveyor/pelorus/konveyor-pelorus-master__4.11.yaml#L122-L124) and used by the [Pelorus E2E script](https://github.com/konveyor/pelorus/blob/master/scripts/run-pelorus-e2e-tests).
+E2E Pull Request jobs consumes Pelorus deployment files, which are defined in the [mig-demo-apps values.yaml](https://github.com/dora-metrics/mig-demo-apps/blob/master/apps/todolist-mongo-go/pelorus/values.yaml) project and requires secrets that are configured using [vault.ci.openshift.org](https://vault.ci.openshift.org). Those secrets are then mounted by the [Prow job definition](https://github.com/openshift/release/blob/master/ci-operator/config/konveyor/pelorus/konveyor-pelorus-master__4.11.yaml#L122-L124) and used by the [Pelorus E2E script](https://github.com/dora-metrics/pelorus/blob/master/scripts/run-pelorus-e2e-tests).
 
-E2E periodic jobs uses deployment files defined in the [mig-demo-apps periodic folder](https://github.com/konveyor/mig-demo-apps/tree/master/apps/todolist-mongo-go/pelorus/periodic). Secrets and invocation script are identical to the Pull Request jobs differing in the [Makefile](https://github.com/konveyor/pelorus/blob/master/Makefile) targets, which uses different arguments passed to the [Pelorus E2E script](https://github.com/konveyor/pelorus/blob/master/scripts/run-pelorus-e2e-tests).
+E2E periodic jobs uses deployment files defined in the [mig-demo-apps periodic folder](https://github.com/konveyor/mig-demo-apps/tree/master/apps/todolist-mongo-go/pelorus/periodic). Secrets and invocation script are identical to the Pull Request jobs differing in the [Makefile](https://github.com/dora-metrics/pelorus/blob/master/Makefile) targets, which uses different arguments passed to the [Pelorus E2E script](https://github.com/dora-metrics/pelorus/blob/master/scripts/run-pelorus-e2e-tests).
 
 Exporters list covered by the Prow CI is available in the [Backend Exporters](#backend-exporters) section.
 

--- a/docs/philosophy/outcomes/SoftwareDeliveryPerformance.md
+++ b/docs/philosophy/outcomes/SoftwareDeliveryPerformance.md
@@ -35,10 +35,10 @@ For an organization-level measurement, aggregate by averaging the lead time for 
 
 The following exporters are required to calculate _Lead Time for Change_:
 
-* The [commit time exporter](https://github.com/konveyor/pelorus/blob/master/exporters/committime) provides the `commit_time` metric, which is the timestamp that a commit was made to source control.
-* The [deploy time exporter](https://github.com/konveyor/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
+* The [commit time exporter](https://github.com/dora-metrics/pelorus/blob/master/exporters/committime) provides the `commit_time` metric, which is the timestamp that a commit was made to source control.
+* The [deploy time exporter](https://github.com/dora-metrics/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
 
-The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/templates/prometheus-rules.yaml). This converts individual `commit_time` and `deploy_time` data points into the following metrics:
+The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/dora-metrics/pelorus/blob/master/charts/pelorus/templates/prometheus-rules.yaml). This converts individual `commit_time` and `deploy_time` data points into the following metrics:
 
 * `sdp:lead_time:by_app` - Calculated lead times by application (`deploy_time - commit_time`)
 * `sdp:lead_time:global` - A Global average of `sdp:lead_time:by_app`
@@ -61,7 +61,7 @@ For an organization-level measurement, take the sum across product-level deploym
 
 The following exporters are required to calculate _Deployment Frequency_:
 
-* The [deploy time exporter](https://github.com/konveyor/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
+* The [deploy time exporter](https://github.com/dora-metrics/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
 
 The dashboard then just tracks a `count_over_time()` of the individual `deploy_time` metrics for the time range selected in the dashboard. It also provides a comparison to the previous time range.
 
@@ -81,9 +81,9 @@ For an organizational-level measurement, average MTTR data across products.
 
 The following exporters are required to calculate _Mean Time to Restore_:
 
-* The [failure exporter](https://github.com/konveyor/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` and `failure_resolution_timestamp` metrics, which attempt to capture the beginning and end of individual failure or degradation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
+* The [failure exporter](https://github.com/dora-metrics/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` and `failure_resolution_timestamp` metrics, which attempt to capture the beginning and end of individual failure or degradation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
 
-The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/konveyor/pelorus/blob/master/charts/deploy/templates/prometheus-rules.yaml). This converts individual `failure_creation_timestamp` and `failure_resolution_timestamp` data points into the following metrics:
+The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/dora-metrics/pelorus/blob/master/charts/deploy/templates/prometheus-rules.yaml). This converts individual `failure_creation_timestamp` and `failure_resolution_timestamp` data points into the following metrics:
 
 * `sdp:time_to_restore` - A calculated time to restore for each failure event (`failure_resolution_timestamp - failure_creation_timestamp`)
 * `sdp:time_to_restore:global` - A global average of all `sdp:time_to_restore` calculations.
@@ -106,10 +106,10 @@ For an organizational-level measurement, expand the scope of the failures captur
 
 The following exporters are require to calculate _Change Failure Rate_:
 
-* The [failure exporter](https://github.com/konveyor/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` metrics, which attempt to capture the beginning of individual failure or degradation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
-* The [deploy time exporter](https://github.com/konveyor/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
+* The [failure exporter](https://github.com/dora-metrics/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` metrics, which attempt to capture the beginning of individual failure or degradation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
+* The [deploy time exporter](https://github.com/dora-metrics/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
 
-The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/konveyor/pelorus/blob/master/charts/deploy/templates/prometheus-rules.yaml). This converts individual `failure_creation_timestamp` and `deploy_time` data points into the following metric:
+The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/dora-metrics/pelorus/blob/master/charts/deploy/templates/prometheus-rules.yaml). This converts individual `failure_creation_timestamp` and `deploy_time` data points into the following metric:
 
 * `sdp:change_failure_rate` - A ratio of the number of failed changes to the total number of changes to the system.
 

--- a/exporters/tests/test_exporters.py
+++ b/exporters/tests/test_exporters.py
@@ -22,7 +22,7 @@ def test_commitmetric_initial(appname):
         ("http://dogs.git.foo/dogs/repo.git", "http", "dogs.git.foo", "repo"),
         ("http://noabank.git.foo/chase/git.git", "http", "noabank.git.foo", "git"),
         ("ssh://git.moos.foo/maverick/tootsie.git", "ssh", "git.moos.foo", "tootsie"),
-        ("git@github.com:konveyor/pelorus.git", "ssh", "github.com", "pelorus"),
+        ("git@github.com:dora-metrics/pelorus.git", "ssh", "github.com", "pelorus"),
         ("https://dev.azure.com/azuretest", "https", "dev.azure.com", "azuretest"),
         (
             "https://gitlab.com/firstgroup/secondgroup/myrepo.git",

--- a/labs/consultant/02-Installation.md
+++ b/labs/consultant/02-Installation.md
@@ -32,7 +32,7 @@ Install Ansible (Used for the demo app)
 
 ## Step 2: Clone the Pelorus repository
 
-    git clone https://github.com/konveyor/pelorus.git
+    git clone https://github.com/dora-metrics/pelorus.git
 
 
 ## Step 3: Create cluster Admin account to install Pelorus

--- a/labs/consultant/03-Exporters.md
+++ b/labs/consultant/03-Exporters.md
@@ -46,7 +46,7 @@ In the next few sections, we'll deploy some exporters that collect data in a sim
         extraEnv:
         - name: APP_FILE
           value: deploytime/app.py
-        source_url: https://github.com/konveyor/pelorus.git
+        source_url: https://github.com/dora-metrics/pelorus.git
 
 We get the information we need about deploy time from OpenShift, so this exporter works out-of-the-box!
 
@@ -73,7 +73,7 @@ Update the `values.yaml` and then upgrade our helm installation of Pelorus to ad
         extraEnv:
         - name: APP_FILE
           value: committime/app.py
-        source_url: https://github.com/konveyor/pelorus.git
+        source_url: https://github.com/dora-metrics/pelorus.git
 
       helm upgrade pelorus charts/pelorus --namespace pelorus
 
@@ -112,7 +112,7 @@ Once again, we will update our values.yaml and upgrade our Pelorus deployment.
         extraEnv:
         - name: APP_FILE
           value: failure/app.py
-        source_url: https://github.com/konveyor/pelorus.git
+        source_url: https://github.com/dora-metrics/pelorus.git
 
       helm upgrade pelorus charts/pelorus --namespace pelorus
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Pelorus Docs
 site_url: https://pelorus.readthedocs.io/en/latest/
 site_description: Metrics that matter
-repo_name: konveyor/pelorus
-repo_url: https://github.com/konveyor/pelorus
+repo_name: dora-metrics/pelorus
+repo_url: https://github.com/dora-metrics/pelorus
 theme:
   name: material
   logo: img/icon-white.png

--- a/mocks/README.md
+++ b/mocks/README.md
@@ -13,7 +13,7 @@ First, you will need to install a container engine like [Podman](https://podman.
 Then clone this repository and execute the following command to startup the mock server.
 
 ```sh
-$ git clone https://github.com/konveyor/pelorus.git
+$ git clone https://github.com/dora-metrics/pelorus.git
 ```
 
 ```sh

--- a/samples/todolist_commit_deploy.md
+++ b/samples/todolist_commit_deploy.md
@@ -33,7 +33,7 @@ oc get all -n pelorus
 ***Note*** pause to allow the install to fully complete.
 
 ## Pelorus configuration
-1. Make a copy of [the values.yaml file in the pelorus repo](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/values.yaml) ([raw link for curl-ing](https://raw.githubusercontent.com/konveyor/pelorus/master/charts/pelorus/values.yaml)) and save it to /var/tmp/values.yaml
+1. Make a copy of [the values.yaml file in the pelorus repo](https://github.com/dora-metrics/pelorus/blob/master/charts/pelorus/values.yaml) ([raw link for curl-ing](https://raw.githubusercontent.com/dora-metrics/pelorus/master/charts/pelorus/values.yaml)) and save it to /var/tmp/values.yaml
 ```
 cp charts/pelorus/values.yaml /var/tmp/
 ```
@@ -51,7 +51,7 @@ exporters:
     - name: NAMESPACES
       value: mongo-persistent
     source_ref: master
-    source_url: https://github.com/konveyor/pelorus.git
+    source_url: https://github.com/dora-metrics/pelorus.git
   - app_name: committime-exporter
     source_context_dir: exporters/
     extraEnv:
@@ -60,7 +60,7 @@ exporters:
     - name: LOG_LEVEL
       value: DEBUG
     source_ref: master
-    source_url: https://github.com/konveyor/pelorus.git
+    source_url: https://github.com/dora-metrics/pelorus.git
 ```
 3. [Documentation regarding values.yaml can be found on our readthedocs page.](https://pelorus.readthedocs.io/en/latest/Configuration/)
   Apply the updated values for Pelorus by executing:
@@ -113,7 +113,7 @@ You should now see at least one measurement for "Lead time for Change" and "Depl
 
 1. Fork the Pelorus git repo
 To develop a Pelorus exporter please fork the Pelorus git source and branch
-  * Fork [the pelorus repo](https://github.com/konveyor/pelorus) to https://github.com/your_org/pelorus
+  * Fork [the pelorus repo](https://github.com/dora-metrics/pelorus) to https://github.com/your_org/pelorus
 
 2. If you have forked Pelorus to a private git repository
 Create a GitHub Personal Access Token and store it as a secret in Openshift:

--- a/samples/todolist_failure_restore.md
+++ b/samples/todolist_failure_restore.md
@@ -29,7 +29,7 @@
 
 
 ## Pelorus configuration
-1. Make a copy of [the values.yaml file in the pelorus repo](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/values.yaml) ([raw link for curl-ing](https://raw.githubusercontent.com/konveyor/pelorus/master/charts/pelorus/values.yaml)) and save it to /var/tmp/values.yaml
+1. Make a copy of [the values.yaml file in the pelorus repo](https://github.com/dora-metrics/pelorus/blob/master/charts/pelorus/values.yaml) ([raw link for curl-ing](https://raw.githubusercontent.com/dora-metrics/pelorus/master/charts/pelorus/values.yaml)) and save it to /var/tmp/values.yaml
 ```
 cp charts/pelorus/values.yaml /var/tmp/
 ```

--- a/scripts/chart-test.sh
+++ b/scripts/chart-test.sh
@@ -2,7 +2,7 @@
 
 # Runs chart-testing (ct CLI) with remote flag to avoid git errors
 
-GIT_REPO=konveyor/pelorus.git
+GIT_REPO=dora-metrics/pelorus.git
 REMOTE=origin
 ORIGIN=$(git remote show origin)
 

--- a/scripts/create_pelorus_operator
+++ b/scripts/create_pelorus_operator
@@ -17,7 +17,7 @@
 
 OPERATOR_PROJECT_NAME=pelorus-operator
 OPERATOR_ORG_NAME=pelorus
-OPERATOR_PROJECT_DOMAIN=pelorus.konveyor.io
+OPERATOR_PROJECT_DOMAIN=pelorus.dora-metrics.io
 
 # Get the full absolute path to the script. Needed while calling the script
 # via various partial paths or sourcing the file from shell
@@ -120,7 +120,7 @@ pushd "${destination_dir}" || exit 2
     operator-sdk create api --helm-chart="${source_dir}" || exit 2
 
     # Correct operator version, to be latest +1
-    OPERATOR_VERSIONS=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq ".tags[] | select(.end_ts == null) | .name" | sed -e 's|\"||g' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' -o | sort --reverse)
+    OPERATOR_VERSIONS=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq ".tags[] | select(.end_ts == null) | .name" | sed -e 's|\"||g' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' -o | sort -t. -nrk1,1 -nrk2,2 -nrk3,3)
     OPERATOR_VERSION=$(echo "$OPERATOR_VERSIONS" | head -1 )
     echo "INFO: Current operator version: ${OPERATOR_VERSION}"
 
@@ -184,7 +184,7 @@ elif [ "$(ls -A "${patches_dir}/bundle-patches"/*.diff 2>/dev/null)" ]; then
         done
 fi
 
-echo "INFO: Adding replaces and skips entries to ${source_dir}${destination_dir}/bundle/manifests/charts.pelorus.konveyor.io_pelorus.yaml"
+echo "INFO: Adding replaces and skips entries to ${source_dir}${destination_dir}/bundle/manifests/charts.pelorus.dora-metrics.io_pelorus.yaml"
 set -e
 $SCRIPT_DIR/specify_operator_update.py $NEW_OPERATOR_VERSION $destination_dir $OPERATOR_VERSIONS
 

--- a/scripts/create_release_pr
+++ b/scripts/create_release_pr
@@ -31,7 +31,7 @@
 # repository.
 
 # Required to get the latest released tag
-PELORUS_API_URL="https://api.github.com/repos/konveyor/pelorus/releases/latest"
+PELORUS_API_URL="https://api.github.com/repos/dora-metrics/pelorus/releases/latest"
 BUILDCONFIG_PATH="charts/pelorus/charts/exporters/templates/_buildconfig.yaml"
 IMAGESTREAM_PATH="charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml"
 PELORUS_CHART="charts/pelorus/Chart.yaml"

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -113,7 +113,7 @@
 +    Our support policy can be found in the [Upstream Support statement](https://github.com/dora-metrics/pelorus/blob/master/docs/UpstreamSupport.md)
 +
 +    ## Code of Conduct
-+    Refer to dora-metrics's Code of Conduct [here](https://github.com/dora-metrics/community/blob/main/CODE_OF_CONDUCT.md).
++    Refer to dora-metrics's Code of Conduct [here](https://github.com/dora-metrics/pelorus/blob/master/CODE_OF_CONDUCT.md).
 +
 +    ## License
 +

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -9,7 +9,7 @@
 +    description: |
 +      Tool that helps IT organizations measure their impact on the overall performance of their organization
 +    operatorframework.io/suggested-namespace: pelorus
-+    repository: https://github.com/konveyor/pelorus/
++    repository: https://github.com/dora-metrics/pelorus/
 +    support: Pelorus Community
 +    containerImage: placeholder
    name: pelorus-operator.v0.0.0
@@ -23,7 +23,7 @@
 +    - description: Pelorus is the Schema for pelorus API to adopt instance to the requested workflow
 +      displayName: Pelorus
 +      kind: Pelorus
-+      name: pelorus.charts.pelorus.konveyor.io
++      name: peloruses.charts.pelorus.dora-metrics.io
 +      version: v1alpha1
 +      specDescriptors:
 +      - path: exporters.instances.[0].app_name
@@ -106,18 +106,18 @@
 +
 +    ## Contributing to Pelorus
 +
-+    If you are interested in contributing to the Pelorus project, please review our Contribution guide which can be found in the [contribution guide](https://github.com/konveyor/pelorus/blob/master/CONTRIBUTING.md)
++    If you are interested in contributing to the Pelorus project, please review our Contribution guide which can be found in the [contribution guide](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)
 +
 +    ## Statement of Support
 +
-+    Our support policy can be found in the [Upstream Support statement](https://github.com/konveyor/pelorus/blob/master/docs/UpstreamSupport.md)
++    Our support policy can be found in the [Upstream Support statement](https://github.com/dora-metrics/pelorus/blob/master/docs/UpstreamSupport.md)
 +
 +    ## Code of Conduct
-+    Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).
++    Refer to dora-metrics's Code of Conduct [here](https://github.com/dora-metrics/community/blob/main/CODE_OF_CONDUCT.md).
 +
 +    ## License
 +
-+    This repository is licensed under the terms of [Apache-2.0 License](https://raw.githubusercontent.com/konveyor/pelorus/master/LICENSE).
++    This repository is licensed under the terms of [Apache-2.0 License](https://raw.githubusercontent.com/dora-metrics/pelorus/master/LICENSE).
    displayName: Pelorus Operator
    icon:
 -  - base64data: ""
@@ -156,7 +156,7 @@
 +  - name: Pelorus Getting Started
 +    url: https://pelorus.readthedocs.io/en/latest/GettingStarted/Overview/
 +  - name: Pelorus GIT repository
-+    url: https://github.com/konveyor/pelorus/
++    url: https://github.com/dora-metrics/pelorus/
    maintainers:
 -  - email: your@email.com
 -    name: Maintainer Name

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -1,10 +1,10 @@
---- config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml.original	2022-12-16 20:39:18.630409481 +0100
-+++ config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml	2022-12-16 20:39:03.674340069 +0100
+--- config/crd/bases/charts.pelorus.dora-metrics.io_peloruses.yaml.original	2022-12-16 20:39:18.630409481 +0100
++++ config/crd/bases/charts.pelorus.dora-metrics.io_peloruses.yaml	2022-12-16 20:39:03.674340069 +0100
 @@ -15,29 +139,201 @@
    - name: v1alpha1
      schema:
        openAPIV3Schema:
--        description: Pelorus is the Schema for the pelorus API
+-        description: Pelorus is the Schema for the peloruses API
 +        description: >-
 +          Configure a running instance of Pelorus
 +        type: object

--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -121,7 +121,7 @@ PELORUS_NAMESPACE="${PELORUS_NAMESPACE}"
 function ogn() { printf "oc get --namespace %s $*\n" "${PELORUS_NAMESPACE}"; oc get --namespace "${PELORUS_NAMESPACE}" "$@"; }
 function ogns() { printf "oc get --namespace %s svc $*\n" "${PELORUS_NAMESPACE}"; oc get --namespace "${PELORUS_NAMESPACE}" svc "$@"; }
 function ornds() { printf "oc rollout status --namespace %s deployments $*\n" "${PELORUS_NAMESPACE}"; oc rollout status --namespace ${PELORUS_NAMESPACE} deployments "$@"; }
-function owpr() { printf "oc wait pod --for=condition=Ready -n %s -l pelorus.konveyor.io/exporter-type=$*\n" "${PELORUS_NAMESPACE}"; oc wait pod --for=condition=Ready -n ${PELORUS_NAMESPACE} -l pelorus.konveyor.io/exporter-type="$*"; }
+function owpr() { printf "oc wait pod --for=condition=Ready -n %s -l pelorus.dora-metrics.io/exporter-type=$*\n" "${PELORUS_NAMESPACE}"; oc wait pod --for=condition=Ready -n ${PELORUS_NAMESPACE} -l pelorus.dora-metrics.io/exporter-type="$*"; }
 function owr() { printf "oc wait --for=condition=Ready -n %s $*\n" "${PELORUS_NAMESPACE}"; oc wait --for=condition=Ready -n ${PELORUS_NAMESPACE} "$*"; }
 set +a
 
@@ -592,7 +592,7 @@ retry 10m 10s oc wait pod --for=condition=Ready -n mongo-persistent -l app=todol
 # Ugly, but let's check if this improves CI
 sleep 60
 
-for exporter_pod in $(oc get pods -n pelorus  -l 'pelorus.konveyor.io/exporter-type in (committime,failure,deploytime)' -o name);
+for exporter_pod in $(oc get pods -n pelorus  -l 'pelorus.dora-metrics.io/exporter-type in (committime,failure,deploytime)' -o name);
 do
     retry 5m 5s owr "$exporter_pod"
 done


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Move Pelorus project to https://github.com/dora-metrics organization.

## Linked Issues

resolves #887

## Testing Instructions

I have run `grep -Iinr "konveyor" . --exclude-dir={.venv,pelorus-operator,.pytest_cache}` to help me change `konveyor` to `dora-metrics`. 

We still need to

- [x] Create CODE_OF_CONDUCT.md in `dora-metrics` org. Depends on: https://github.com/dora-metrics/pelorus/pull/910
- [x] Test if nothing breaks
  - [x] Test Operator `operator-sdk run bundle quay.io/msouzaol/pelorus-operator-bundle:v0.0.11 --namespace pelorus` 
- [x] Check if run-pelorus-e2e-tests needs changes (and makefile commands)
  - [x] Change https://github.com/konveyor/mig-demo-apps `apps/todolist-mongo-go/pelorus` files

Did not change pelorus operator folder, as I think is best to first have Michal's PR there, but I have run the create script on this branch and only got this with `grep`
```
./pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml:143:    [YouTube Video](https://www.youtube.com/watch?v=VPCOIfDcgso) with the Pelorus in action recorded during online Konveyor Community event.
```

