### PR TITLE
fix: Azure devops URL parser

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -558,14 +558,40 @@ For testing changes to the helm chart, you should just follow the [standard inst
 * All expected pods are running and healthy
 * Any expected behavior changes mentioned in the PR can be observed.
 
-A different way is to simply run e2e-tests against your cluster, to do so, **ENSURE** your pelorus namespace is either not existing or no resources are within that namespace.
+A different way is to simply run e2e-tests against your cluster. To do so, first export the necessary secrets to run the script, by running
+```shell
+export TOKEN=<YOUR_GITHUB_TOKEN>
+export GITLAB_API_TOKEN=<YOUR_GITLAB_TOKEN>
+export GITEA_API_TOKEN=<YOUR_GITEA_TOKEN>
+export BITBUCKET_API_USER=<YOUR_BITBUCKET_USER>
+export BITBUCKET_API_TOKEN=<YOUR_BITBUCKET_TOKEN>
+export JIRA_USER=<YOUR_JIRA_USER>
+export JIRA_TOKEN=<YOUR_JIRA_TOKEN>
+```
 
-    ​export KUBECONFIG=/path/to/kubeconfig_file
-    # DANGEROUS as this will remove your previously deployed pelorus instance
-    oc delete namespace pelorus
-    make e2e-tests
-    # Check if command ran without failures
-    echo $?
+Then, log in to your OpenShift cluster and **ENSURE** your pelorus namespace does not exist (if it exist, you can delete it running `oc delete namespace pelorus`), and run
+```
+make e2e-tests
+```
+which is an alias to `./scripts/run-pelorus-e2e-tests -o konveyor -e failure,gitlab_committime,gitea_committime,bitbucket_committime,jira_committime,jira_custom_committime -t`
+
+To run e2e-tests from current branch, first create a PR in Pelorus project for it and export the necessary environment variables to run the script, by running
+```
+export REPO_NAME=pelorus
+export PULL_NUMBER=THE_PR_NUMBER
+```
+
+For more information, run
+```
+./scripts/run-pelorus-e2e-tests -h
+```
+
+To delete the objects created by the script, run
+```
+curl https://raw.githubusercontent.com/konveyor/mig-demo-apps/master/apps/todolist-mongo-go/mongo-persistent.yaml | oc delete -f -
+helm uninstall pelorus --namespace pelorus
+helm uninstall operators --namespace pelorus
+```
 
 You can do some rudimentary linting with `make chart-lint`.
 

--- a/docs/GettingStarted/configuration/ExporterCommittime.md
+++ b/docs/GettingStarted/configuration/ExporterCommittime.md
@@ -96,6 +96,8 @@ There are additional options available when the [PROVIDER](#provider) type is se
 | [LOG_LEVEL](#log_level) | no | `INFO` |
 | [APP_LABEL](#app_label) | no | `app.kubernetes.io/name` |
 | [PELORUS_DEFAULT_KEYWORD](#pelorus_default_keyword) | no | `default` |
+| [COMMIT_HASH_ANNOTATION](#commit_hash_annotation) | no | `io.openshift.build.commit.id` |
+| [COMMIT_REPO_URL_ANNOTATION](#commit_repo_url_annotation) | no | `io.openshift.build.source-location` |
 | [PROVIDER](#provider) | no | `git` |
 
 ###### LOG_LEVEL
@@ -121,6 +123,22 @@ There are additional options available when the [PROVIDER](#provider) type is se
 - **Type:** string
 
 : Used only when configuring instance using ConfigMap. It is the ConfigMap value that represents `default` value. If specified it's used in other data values to indicate "Default Value" should be used.
+
+###### COMMIT_HASH_ANNOTATION
+
+- **Required:** no
+    - **Default Value:** io.openshift.build.commit.id
+- **Type:** string
+
+: Annotation name associated with the Build from which hash is used to calculate commit time.
+
+###### COMMIT_REPO_URL_ANNOTATION
+
+- **Required:** no
+    - **Default Value:** io.openshift.build.source-location
+- **Type:** string
+
+: Annotation name associated with the Build from which GIT repository URL is used to calculate commit time.
 
 ###### PROVIDER
 
@@ -198,26 +216,8 @@ Those options are only applicable to the Commit Time Exporter when the [PROVIDER
 
 | Variable | Required | Default Value |
 |----------|----------|---------------|
-| [COMMIT_HASH_ANNOTATION](#commit_hash_annotation) | no | `io.openshift.build.commit.id` |
-| [COMMIT_REPO_URL_ANNOTATION](#commit_repo_url_annotation) | no | `io.openshift.build.source-location` |
 | [COMMIT_DATE_ANNOTATION](#commit_date_annotation) | no | `io.openshift.build.commit.date` |
 | [COMMIT_DATE_FORMAT](#commit_date_format) | no | `%a %b %d %H:%M:%S %Y %z` |
-
-###### COMMIT_HASH_ANNOTATION
-
-- **Required:** no
-    - **Default Value:** io.openshift.build.commit.id
-- **Type:** string
-
-: Annotation name associated with the Build from which hash is used to calculate commit time.
-
-###### COMMIT_REPO_URL_ANNOTATION
-
-- **Required:** no
-    - **Default Value:** io.openshift.build.source-location
-- **Type:** string
-
-: Annotation name associated with the Build from which GIT repository URL is used to calculate commit time.
 
 ###### COMMIT_DATE_ANNOTATION
 

--- a/docs/GettingStarted/configuration/ExporterCommittime.md
+++ b/docs/GettingStarted/configuration/ExporterCommittime.md
@@ -96,8 +96,6 @@ There are additional options available when the [PROVIDER](#provider) type is se
 | [LOG_LEVEL](#log_level) | no | `INFO` |
 | [APP_LABEL](#app_label) | no | `app.kubernetes.io/name` |
 | [PELORUS_DEFAULT_KEYWORD](#pelorus_default_keyword) | no | `default` |
-| [COMMIT_HASH_ANNOTATION](#commit_hash_annotation) | no | `io.openshift.build.commit.id` |
-| [COMMIT_REPO_URL_ANNOTATION](#commit_repo_url_annotation) | no | `io.openshift.build.source-location` |
 | [PROVIDER](#provider) | no | `git` |
 
 ###### LOG_LEVEL
@@ -123,22 +121,6 @@ There are additional options available when the [PROVIDER](#provider) type is se
 - **Type:** string
 
 : Used only when configuring instance using ConfigMap. It is the ConfigMap value that represents `default` value. If specified it's used in other data values to indicate "Default Value" should be used.
-
-###### COMMIT_HASH_ANNOTATION
-
-- **Required:** no
-    - **Default Value:** io.openshift.build.commit.id
-- **Type:** string
-
-: Annotation name associated with the Build from which hash is used to calculate commit time.
-
-###### COMMIT_REPO_URL_ANNOTATION
-
-- **Required:** no
-    - **Default Value:** io.openshift.build.source-location
-- **Type:** string
-
-: Annotation name associated with the Build from which GIT repository URL is used to calculate commit time.
 
 ###### PROVIDER
 
@@ -201,13 +183,11 @@ Those options are only applicable to the Commit Time Exporter when the [PROVIDER
 ###### GIT_API
 
 - **Required:** yes
-    - Only applicable for [PROVIDER](#provider) value: `git` or unset
+    - Only applicable for [GIT_PROVIDER](#git_provider) value: `github` (or unset), `gitea` or `azure-devops`
     - **Default Value:**
         - `api.github.com` for `github` [GIT_PROVIDER](#git_provider)
         - `dev.azure.com` for `azure-devops` [GIT_PROVIDER](#git_provider)
         - `try.gitea.io` for `gitea` [GIT_PROVIDER](#git_provider)
-        - **unset** for `gitlab` [GIT_PROVIDER](#git_provider)
-        - **unset** for `bitbucket` [GIT_PROVIDER](#git_provider)
 - **Type:** string
 
 : GitHub, Gitea or Azure DevOps API FQDN. This allows the override for Enterprise users.
@@ -218,8 +198,26 @@ Those options are only applicable to the Commit Time Exporter when the [PROVIDER
 
 | Variable | Required | Default Value |
 |----------|----------|---------------|
-| [COMMIT_DATE_ANNOTATION](#api_user) | no | `io.openshift.build.commit.date` |
-| [COMMIT_DATE_FORMAT](#token) | no | `%a %b %d %H:%M:%S %Y %z` |
+| [COMMIT_HASH_ANNOTATION](#commit_hash_annotation) | no | `io.openshift.build.commit.id` |
+| [COMMIT_REPO_URL_ANNOTATION](#commit_repo_url_annotation) | no | `io.openshift.build.source-location` |
+| [COMMIT_DATE_ANNOTATION](#commit_date_annotation) | no | `io.openshift.build.commit.date` |
+| [COMMIT_DATE_FORMAT](#commit_date_format) | no | `%a %b %d %H:%M:%S %Y %z` |
+
+###### COMMIT_HASH_ANNOTATION
+
+- **Required:** no
+    - **Default Value:** io.openshift.build.commit.id
+- **Type:** string
+
+: Annotation name associated with the Build from which hash is used to calculate commit time.
+
+###### COMMIT_REPO_URL_ANNOTATION
+
+- **Required:** no
+    - **Default Value:** io.openshift.build.source-location
+- **Type:** string
+
+: Annotation name associated with the Build from which GIT repository URL is used to calculate commit time.
 
 ###### COMMIT_DATE_ANNOTATION
 

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -62,16 +62,6 @@ class ImageCommittimeConfig:
 
     app_label: str = pelorus.DEFAULT_APP_LABEL
 
-    hash_annotation_name: str = field(
-        default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
-        metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),
-    )
-
-    repo_url_annotation_name: str = field(
-        default=CommitMetric._ANNOTATION_MAPPIG["repo_url"],
-        metadata=env_vars(COMMIT_REPO_URL_ANNOTATION_ENV),
-    )
-
     # Used to convert time and date found in the
     # Docker Label io.openshift.build.commit.date
     # or annotation for the Image
@@ -82,6 +72,18 @@ class ImageCommittimeConfig:
     date_annotation_name: str = field(
         default=CommitMetric._ANNOTATION_MAPPIG["commit_time"],
         metadata=env_vars(COMMIT_DATE_ANNOTATION_ENV),
+    )
+
+    # TODO hash_annotation_name and repo_url_annotation_name seem to be
+    # unnecessary
+    hash_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
+        metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),
+    )
+
+    repo_url_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["repo_url"],
+        metadata=env_vars(COMMIT_REPO_URL_ANNOTATION_ENV),
     )
 
     def make_collector(self) -> AbstractCommitCollector:
@@ -98,9 +100,9 @@ class ImageCommittimeConfig:
             username="",
             token="",
             app_label=self.app_label,
+            date_annotation_name=self.date_annotation_name,
             hash_annotation_name=self.hash_annotation_name,
             repo_url_annotation_name=self.repo_url_annotation_name,
-            date_annotation_name=self.date_annotation_name,
         )
 
 
@@ -132,6 +134,18 @@ class GitCommittimeConfig:
         default=pelorus.DEFAULT_TLS_VERIFY, converter=attrs.converters.to_bool
     )
 
+    # TODO hash_annotation_name and repo_url_annotation_name seem to be
+    # unnecessary
+    hash_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
+        metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),
+    )
+
+    repo_url_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["repo_url"],
+        metadata=env_vars(COMMIT_REPO_URL_ANNOTATION_ENV),
+    )
+
     def __attrs_post_init__(self):
         if not (self.username and self.token):
             logging.warning(
@@ -154,6 +168,8 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
             )
         if git_provider == "github":
             if self.git_api:
@@ -167,6 +183,8 @@ class GitCommittimeConfig:
                 namespaces=self.namespaces,
                 tls_verify=self.tls_verify,
                 app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
         if git_provider == "bitbucket":
@@ -177,6 +195,8 @@ class GitCommittimeConfig:
                 namespaces=self.namespaces,
                 tls_verify=self.tls_verify,
                 app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
             )
         if git_provider == "gitea":
             if self.git_api:
@@ -189,6 +209,8 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
         if git_provider == "azure-devops":
@@ -202,6 +224,8 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
 

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -15,6 +15,8 @@ from committime import CommitMetric
 from committime.collector_azure_devops import AzureDevOpsCommitCollector
 from committime.collector_base import (
     COMMIT_DATE_ANNOTATION_ENV,
+    COMMIT_HASH_ANNOTATION_ENV,
+    COMMIT_REPO_URL_ANNOTATION_ENV,
     AbstractCommitCollector,
 )
 from committime.collector_bitbucket import BitbucketCommitCollector
@@ -58,6 +60,18 @@ class CommittimeTypeConfig:
 class ImageCommittimeConfig:
     kube_client: DynamicClient = field(metadata=no_env_vars())
 
+    app_label: str = pelorus.DEFAULT_APP_LABEL
+
+    hash_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
+        metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),
+    )
+
+    repo_url_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["repo_url"],
+        metadata=env_vars(COMMIT_REPO_URL_ANNOTATION_ENV),
+    )
+
     # Used to convert time and date found in the
     # Docker Label io.openshift.build.commit.date
     # or annotation for the Image
@@ -83,6 +97,10 @@ class ImageCommittimeConfig:
             date_format=self.date_format,
             username="",
             token="",
+            app_label=self.app_label,
+            hash_annotation_name=self.hash_annotation_name,
+            repo_url_annotation_name=self.repo_url_annotation_name,
+            date_annotation_name=self.date_annotation_name,
         )
 
 
@@ -106,6 +124,18 @@ class GitCommittimeConfig:
     git_provider: str = field(
         default=pelorus.DEFAULT_GIT,
         validator=attrs.validators.in_(PROVIDER_CLASSES_BY_NAME.keys()),
+    )
+
+    app_label: str = pelorus.DEFAULT_APP_LABEL
+
+    hash_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
+        metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),
+    )
+
+    repo_url_annotation_name: str = field(
+        default=CommitMetric._ANNOTATION_MAPPIG["repo_url"],
+        metadata=env_vars(COMMIT_REPO_URL_ANNOTATION_ENV),
     )
 
     tls_verify: bool = field(
@@ -133,6 +163,9 @@ class GitCommittimeConfig:
                 username=self.username,
                 token=self.token,
                 namespaces=self.namespaces,
+                app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
             )
         if git_provider == "github":
             if self.git_api:
@@ -145,6 +178,9 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 tls_verify=self.tls_verify,
+                app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
         if git_provider == "bitbucket":
@@ -154,6 +190,9 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 tls_verify=self.tls_verify,
+                app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
             )
         if git_provider == "gitea":
             if self.git_api:
@@ -165,15 +204,25 @@ class GitCommittimeConfig:
                 username=self.username,
                 token=self.token,
                 namespaces=self.namespaces,
+                app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
         if git_provider == "azure-devops":
+            if self.git_api:
+                api = dict(git_api=self.git_api)
+            else:
+                api = {}
             return AzureDevOpsCommitCollector(
                 kube_client=self.kube_client,
                 username=self.username,
                 token=self.token,
                 namespaces=self.namespaces,
-                git_api=self.git_api,
+                app_label=self.app_label,
+                hash_annotation_name=self.hash_annotation_name,
+                repo_url_annotation_name=self.repo_url_annotation_name,
+                **api,
             )
 
         raise ValueError(
@@ -181,7 +230,8 @@ class GitCommittimeConfig:
         )  # should be unreachable
 
 
-if __name__ == "__main__":
+def set_up() -> AbstractCommitCollector:
+    # TODO refactor: all exporters have same structure
     pelorus.setup_logging()
     provider_config = load_and_log(CommittimeTypeConfig)
 
@@ -199,6 +249,12 @@ if __name__ == "__main__":
     collector = config.make_collector()
 
     REGISTRY.register(collector)
+    return collector
+
+
+if __name__ == "__main__":
+    set_up()
+    # TODO refactor: create function, all exporters have same structure
     start_http_server(8080)
 
     while True:

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -128,16 +128,6 @@ class GitCommittimeConfig:
 
     app_label: str = pelorus.DEFAULT_APP_LABEL
 
-    hash_annotation_name: str = field(
-        default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
-        metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),
-    )
-
-    repo_url_annotation_name: str = field(
-        default=CommitMetric._ANNOTATION_MAPPIG["repo_url"],
-        metadata=env_vars(COMMIT_REPO_URL_ANNOTATION_ENV),
-    )
-
     tls_verify: bool = field(
         default=pelorus.DEFAULT_TLS_VERIFY, converter=attrs.converters.to_bool
     )
@@ -164,8 +154,6 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 app_label=self.app_label,
-                hash_annotation_name=self.hash_annotation_name,
-                repo_url_annotation_name=self.repo_url_annotation_name,
             )
         if git_provider == "github":
             if self.git_api:
@@ -179,8 +167,6 @@ class GitCommittimeConfig:
                 namespaces=self.namespaces,
                 tls_verify=self.tls_verify,
                 app_label=self.app_label,
-                hash_annotation_name=self.hash_annotation_name,
-                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
         if git_provider == "bitbucket":
@@ -191,8 +177,6 @@ class GitCommittimeConfig:
                 namespaces=self.namespaces,
                 tls_verify=self.tls_verify,
                 app_label=self.app_label,
-                hash_annotation_name=self.hash_annotation_name,
-                repo_url_annotation_name=self.repo_url_annotation_name,
             )
         if git_provider == "gitea":
             if self.git_api:
@@ -205,8 +189,6 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 app_label=self.app_label,
-                hash_annotation_name=self.hash_annotation_name,
-                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
         if git_provider == "azure-devops":
@@ -220,8 +202,6 @@ class GitCommittimeConfig:
                 token=self.token,
                 namespaces=self.namespaces,
                 app_label=self.app_label,
-                hash_annotation_name=self.hash_annotation_name,
-                repo_url_annotation_name=self.repo_url_annotation_name,
                 **api,
             )
 

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -76,6 +76,8 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
 
     commit_dict: dict[str, Optional[float]] = field(factory=dict, init=False)
 
+    # TODO hash_annotation_name and repo_url_annotation_name seem to be
+    # unnecessary
     hash_annotation_name: str = field(
         default=CommitMetric._ANNOTATION_MAPPIG["commit_hash"],
         metadata=env_vars(COMMIT_HASH_ANNOTATION_ENV),

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -23,6 +23,7 @@ from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
 import pelorus
+from failure.collector_base import AbstractFailureCollector
 from failure.collector_github import GithubFailureCollector
 from failure.collector_jira import JiraFailureCollector
 from failure.collector_pagerduty import PagerdutyFailureCollector
@@ -49,14 +50,20 @@ class FailureCollectorConfig:
         return load_and_log(PROVIDER_TYPES[self.tracker_provider])
 
 
-if __name__ == "__main__":
-    # TODO refactor: create function, all exporters have same structure
+def set_up() -> AbstractFailureCollector:
+    # TODO refactor: all exporters have same structure
     pelorus.setup_logging()
 
     config = load_and_log(FailureCollectorConfig)
     collector = config.create()
 
     REGISTRY.register(collector)
+    return collector
+
+
+if __name__ == "__main__":
+    set_up()
+    # TODO refactor: create function, all exporters have same structure
     start_http_server(8080)
 
     while True:

--- a/exporters/requirements.txt
+++ b/exporters/requirements.txt
@@ -14,7 +14,7 @@ requests               # module requests
 
 
 # Failure exporter
-jira                   # module jira
+jira == 3.4.1          # module jira - Related issue https://github.com/dora-metrics/pelorus/issues/902
 pytz                   # module pytz
 requests               # module requests
 Pygithub               # module github

--- a/exporters/tests/__init__.py
+++ b/exporters/tests/__init__.py
@@ -1,6 +1,11 @@
+import logging
+import os
+from typing import Callable, Dict
+from unittest.mock import Mock, patch
+
 from prometheus_client.core import REGISTRY
 
-from pelorus import AbstractPelorusExporter
+from pelorus import AbstractPelorusExporter, utils
 
 
 def run_prometheus_register(collector: AbstractPelorusExporter) -> None:
@@ -8,3 +13,31 @@ def run_prometheus_register(collector: AbstractPelorusExporter) -> None:
         REGISTRY.register(collector)
     finally:
         REGISTRY.unregister(collector)
+
+
+class MockExporter:
+    def __init__(
+        self, set_up: Callable[[], AbstractPelorusExporter], mock_kube_client=Mock()
+    ) -> None:
+        self.set_up = set_up
+        self.mock_kube_client = mock_kube_client
+
+    def run_app(self, arguments: Dict[str, str]) -> AbstractPelorusExporter:
+        """Run set up of exporter app with desired environment variables."""
+        try:
+            collector = None
+            logging.getLogger().disabled = False
+            for key, value in arguments.items():
+                os.environ[key] = value
+            with patch.object(utils, "get_k8s_client") as mock_kube_client:
+                mock_kube_client.return_value.resources.get.side_effect = (
+                    self.mock_kube_client
+                )
+                collector = self.set_up()
+            return collector
+        finally:
+            for key in arguments:
+                del os.environ[key]
+            if collector:
+                REGISTRY.unregister(collector)
+            logging.getLogger().disabled = True

--- a/exporters/tests/test_committime_exporter_app.py
+++ b/exporters/tests/test_committime_exporter_app.py
@@ -1,0 +1,227 @@
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+from unittest.mock import Mock
+
+import pytest
+from kubernetes.dynamic.resource import ResourceInstance
+
+from committime.app import set_up
+from committime.collector_azure_devops import AzureDevOpsCommitCollector
+from tests import MockExporter
+
+
+def name_space(name: str):
+    namespace = Mock()
+    namespace.metadata.name = name
+    return namespace
+
+
+namespaces = Mock()
+namespaces.get.return_value.items = {name_space("test1"), name_space("test2")}
+builds = Mock()
+builds.get.return_value = {
+    ResourceInstance(
+        client=None,
+        instance={"kind": "BuildList", "apiVersion": "build.openshift.io/v1"},
+    )
+}
+images = Mock()
+images.get.return_value = {
+    ResourceInstance(
+        client=None,
+        instance={"kind": "ImageList", "apiVersion": "image.openshift.io/v1"},
+    )
+}
+
+
+matcher = {
+    "Namespace": namespaces,
+    "Build": builds,
+    "Image": images,
+}
+
+
+# TODO proper mock kubernetes objects
+def mocked(api_version, kind):
+    return matcher[kind]
+
+
+mocked_commit_time_exporter = MockExporter(set_up=set_up, mock_kube_client=mocked)
+
+
+@pytest.mark.parametrize("provider", ["imagy", "zip"])
+@pytest.mark.integration
+def test_app_invalid_provider(provider: str, caplog: pytest.LogCaptureFixture):
+    with pytest.raises(ValueError):
+        mocked_commit_time_exporter.run_app({"PROVIDER": provider})
+
+    # TODO shouldn't be 1?
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+
+
+@pytest.mark.parametrize("provider", ["wrong", "git_hub", "GITHUB", "GitHub"])
+@pytest.mark.integration
+def test_app_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFixture):
+    with pytest.raises(ValueError):
+        mocked_commit_time_exporter.run_app({"GIT_PROVIDER": provider})
+
+    # TODO shouldn't be 1?
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+
+
+# TODO mock kubernetes/OpenShift objects so a call to azure API is made
+# @pytest.mark.integration
+# def test_app_azure_devops_without_required_options(caplog: pytest.LogCaptureFixture):
+#     run_app({"GIT_PROVIDER": "azure-devops"})
+
+#     # number of error logs
+#     assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+
+
+@pytest.mark.integration
+def test_app_azure_devops(caplog: pytest.LogCaptureFixture):
+    mocked_exporter = mocked_commit_time_exporter.run_app(
+        {
+            "GIT_PROVIDER": "azure-devops",
+            "API_USER": "fake_user",
+            "TOKEN": "fake_token",
+        }
+    )
+
+    assert "app_label='app.kubernetes.io/name'" in caplog.text
+    assert mocked_exporter.app_label == "app.kubernetes.io/name"
+    assert "hash_annotation_name='io.openshift.build.commit.id'" in caplog.text
+    assert mocked_exporter.hash_annotation_name == "io.openshift.build.commit.id"
+    assert (
+        "repo_url_annotation_name='io.openshift.build.source-location'" in caplog.text
+    )
+    assert (
+        mocked_exporter.repo_url_annotation_name == "io.openshift.build.source-location"
+    )
+    assert "provider='git'" in caplog.text
+    assert "git_provider='azure-devops'" in caplog.text
+    assert isinstance(mocked_exporter, AzureDevOpsCommitCollector)
+    assert "username='fake_user'" in caplog.text
+    assert mocked_exporter.username == "fake_user"
+    assert "token=REDACTED, from env var TOKEN" in caplog.text
+    assert mocked_exporter.token == "fake_token"
+    # TODO assert "git_api='https://dev.azure.com'" in caplog.text
+    assert mocked_exporter.git_api.url == "https://dev.azure.com"
+    assert "No namespaces specified, watching all namespaces" in caplog.text
+    assert len(mocked_exporter.namespaces) == 0
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_with_all_options(caplog: pytest.LogCaptureFixture):
+    mocked_exporter = mocked_commit_time_exporter.run_app(
+        {
+            "LOG_LEVEL": "DEBUG",
+            "APP_LABEL": "custom",
+            # TODO how to test?
+            "PELORUS_DEFAULT_KEYWORD": "another",
+            "COMMIT_HASH_ANNOTATION": "annotation",
+            "COMMIT_REPO_URL_ANNOTATION": "repo url",
+            "PROVIDER": "git",
+            "GIT_PROVIDER": "azure-devops",
+            "NAMESPACES": "oi",
+            "API_USER": "fake_user",
+            "TOKEN": "fake_token",
+            "GIT_API": "custom.io",
+        }
+    )
+
+    assert "app_label='custom'" in caplog.text
+    assert mocked_exporter.app_label == "custom"
+    assert "hash_annotation_name='annotation'" in caplog.text
+    assert mocked_exporter.hash_annotation_name == "annotation"
+    assert "repo_url_annotation_name='repo url'" in caplog.text
+    assert mocked_exporter.repo_url_annotation_name == "repo url"
+    assert "provider='git'" in caplog.text
+    assert "git_provider='azure-devops'" in caplog.text
+    assert isinstance(mocked_exporter, AzureDevOpsCommitCollector)
+    assert "username='fake_user'" in caplog.text
+    assert mocked_exporter.username == "fake_user"
+    assert "token=REDACTED, from env var TOKEN" in caplog.text
+    assert mocked_exporter.token == "fake_token"
+    assert "git_api='custom.io'" in caplog.text
+    assert mocked_exporter.git_api.url == "https://custom.io"
+    assert "Watching namespaces: {'oi'}" in caplog.text
+    assert len(mocked_exporter.namespaces) == 1
+    assert "oi" in mocked_exporter.namespaces
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_image(caplog: pytest.LogCaptureFixture):
+    mocked_exporter = mocked_commit_time_exporter.run_app(
+        {
+            "PROVIDER": "image",
+        }
+    )
+
+    assert "app_label='app.kubernetes.io/name'" in caplog.text
+    assert mocked_exporter.app_label == "app.kubernetes.io/name"
+    assert "hash_annotation_name='io.openshift.build.commit.id'" in caplog.text
+    assert mocked_exporter.hash_annotation_name == "io.openshift.build.commit.id"
+    assert (
+        "repo_url_annotation_name='io.openshift.build.source-location'" in caplog.text
+    )
+    assert (
+        mocked_exporter.repo_url_annotation_name == "io.openshift.build.source-location"
+    )
+    assert "provider='image'" in caplog.text
+    assert "date_annotation_name='io.openshift.build.commit.date'" in caplog.text
+    assert mocked_exporter.date_annotation_name == "io.openshift.build.commit.date"
+    assert "date_format='%a %b %d %H:%M:%S %Y %z'" in caplog.text
+    assert mocked_exporter.date_format == "%a %b %d %H:%M:%S %Y %z"
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_image_with_all_options(caplog: pytest.LogCaptureFixture):
+    mocked_exporter = mocked_commit_time_exporter.run_app(
+        {
+            "LOG_LEVEL": "DEBUG",
+            "PROVIDER": "image",
+            "APP_LABEL": "another.one",
+            # TODO how to test?
+            "PELORUS_DEFAULT_KEYWORD": "another",
+            "COMMIT_HASH_ANNOTATION": "custom annotation",
+            "COMMIT_REPO_URL_ANNOTATION": "custom repo url",
+            "COMMIT_DATE_ANNOTATION": "custom date annotation",
+            "COMMIT_DATE_FORMAT": "custom format",
+        }
+    )
+
+    assert "app_label='another.one'" in caplog.text
+    assert mocked_exporter.app_label == "another.one"
+    assert "hash_annotation_name='custom annotation'" in caplog.text
+    assert mocked_exporter.hash_annotation_name == "custom annotation"
+    assert "repo_url_annotation_name='custom repo url'" in caplog.text
+    assert mocked_exporter.repo_url_annotation_name == "custom repo url"
+    assert "provider='image'" in caplog.text
+    assert "date_annotation_name='custom date annotation'" in caplog.text
+    assert mocked_exporter.date_annotation_name == "custom date annotation"
+    assert "date_format='custom format'" in caplog.text
+    assert mocked_exporter.date_format == "custom format"
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0

--- a/exporters/tests/test_committime_exporter_app.py
+++ b/exporters/tests/test_committime_exporter_app.py
@@ -75,7 +75,7 @@ def test_app_invalid_provider(provider: str, caplog: pytest.LogCaptureFixture):
 
 @pytest.mark.parametrize("provider", ["wrong", "git_hub", "GITHUB", "GitHub"])
 @pytest.mark.integration
-def test_app_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFixture):
+def test_app_git_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFixture):
     with pytest.raises(ValueError):
         mocked_commit_time_exporter.run_app({"GIT_PROVIDER": provider})
 
@@ -86,7 +86,7 @@ def test_app_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFixtur
 
 # TODO mock kubernetes/OpenShift objects so a call to azure API is made
 # @pytest.mark.integration
-# def test_app_azure_devops_without_required_options(caplog: pytest.LogCaptureFixture):
+# def test_app_git_azure_devops_without_required_options(caplog: pytest.LogCaptureFixture):
 #     run_app({"GIT_PROVIDER": "azure-devops"})
 
 #     # number of error logs
@@ -94,7 +94,7 @@ def test_app_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFixtur
 
 
 @pytest.mark.integration
-def test_app_azure_devops(caplog: pytest.LogCaptureFixture):
+def test_app_git_azure_devops(caplog: pytest.LogCaptureFixture):
     mocked_exporter = mocked_commit_time_exporter.run_app(
         {
             "GIT_PROVIDER": "azure-devops",
@@ -105,14 +105,6 @@ def test_app_azure_devops(caplog: pytest.LogCaptureFixture):
 
     assert "app_label='app.kubernetes.io/name'" in caplog.text
     assert mocked_exporter.app_label == "app.kubernetes.io/name"
-    assert "hash_annotation_name='io.openshift.build.commit.id'" in caplog.text
-    assert mocked_exporter.hash_annotation_name == "io.openshift.build.commit.id"
-    assert (
-        "repo_url_annotation_name='io.openshift.build.source-location'" in caplog.text
-    )
-    assert (
-        mocked_exporter.repo_url_annotation_name == "io.openshift.build.source-location"
-    )
     assert "provider='git'" in caplog.text
     assert "git_provider='azure-devops'" in caplog.text
     assert isinstance(mocked_exporter, AzureDevOpsCommitCollector)
@@ -129,18 +121,16 @@ def test_app_azure_devops(caplog: pytest.LogCaptureFixture):
 
 
 @pytest.mark.integration
-def test_app_with_all_options(caplog: pytest.LogCaptureFixture):
+def test_app_git_with_all_options(caplog: pytest.LogCaptureFixture):
     mocked_exporter = mocked_commit_time_exporter.run_app(
         {
             "LOG_LEVEL": "DEBUG",
             "APP_LABEL": "custom",
             # TODO how to test?
             "PELORUS_DEFAULT_KEYWORD": "another",
-            "COMMIT_HASH_ANNOTATION": "annotation",
-            "COMMIT_REPO_URL_ANNOTATION": "repo url",
             "PROVIDER": "git",
             "GIT_PROVIDER": "azure-devops",
-            "NAMESPACES": "oi",
+            "NAMESPACES": "test1",
             "API_USER": "fake_user",
             "TOKEN": "fake_token",
             "GIT_API": "custom.io",
@@ -149,10 +139,6 @@ def test_app_with_all_options(caplog: pytest.LogCaptureFixture):
 
     assert "app_label='custom'" in caplog.text
     assert mocked_exporter.app_label == "custom"
-    assert "hash_annotation_name='annotation'" in caplog.text
-    assert mocked_exporter.hash_annotation_name == "annotation"
-    assert "repo_url_annotation_name='repo url'" in caplog.text
-    assert mocked_exporter.repo_url_annotation_name == "repo url"
     assert "provider='git'" in caplog.text
     assert "git_provider='azure-devops'" in caplog.text
     assert isinstance(mocked_exporter, AzureDevOpsCommitCollector)
@@ -162,9 +148,9 @@ def test_app_with_all_options(caplog: pytest.LogCaptureFixture):
     assert mocked_exporter.token == "fake_token"
     assert "git_api='custom.io'" in caplog.text
     assert mocked_exporter.git_api.url == "https://custom.io"
-    assert "Watching namespaces: {'oi'}" in caplog.text
+    assert "Watching namespaces: {'test1'}" in caplog.text
     assert len(mocked_exporter.namespaces) == 1
-    assert "oi" in mocked_exporter.namespaces
+    assert "test1" in mocked_exporter.namespaces
     # number of error logs
     assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
 
@@ -179,6 +165,7 @@ def test_app_image(caplog: pytest.LogCaptureFixture):
 
     assert "app_label='app.kubernetes.io/name'" in caplog.text
     assert mocked_exporter.app_label == "app.kubernetes.io/name"
+    assert "provider='image'" in caplog.text
     assert "hash_annotation_name='io.openshift.build.commit.id'" in caplog.text
     assert mocked_exporter.hash_annotation_name == "io.openshift.build.commit.id"
     assert (
@@ -187,7 +174,6 @@ def test_app_image(caplog: pytest.LogCaptureFixture):
     assert (
         mocked_exporter.repo_url_annotation_name == "io.openshift.build.source-location"
     )
-    assert "provider='image'" in caplog.text
     assert "date_annotation_name='io.openshift.build.commit.date'" in caplog.text
     assert mocked_exporter.date_annotation_name == "io.openshift.build.commit.date"
     assert "date_format='%a %b %d %H:%M:%S %Y %z'" in caplog.text
@@ -214,11 +200,11 @@ def test_app_image_with_all_options(caplog: pytest.LogCaptureFixture):
 
     assert "app_label='another.one'" in caplog.text
     assert mocked_exporter.app_label == "another.one"
+    assert "provider='image'" in caplog.text
     assert "hash_annotation_name='custom annotation'" in caplog.text
     assert mocked_exporter.hash_annotation_name == "custom annotation"
     assert "repo_url_annotation_name='custom repo url'" in caplog.text
     assert mocked_exporter.repo_url_annotation_name == "custom repo url"
-    assert "provider='image'" in caplog.text
     assert "date_annotation_name='custom date annotation'" in caplog.text
     assert mocked_exporter.date_annotation_name == "custom date annotation"
     assert "date_format='custom format'" in caplog.text

--- a/exporters/tests/test_committime_exporter_app.py
+++ b/exporters/tests/test_committime_exporter_app.py
@@ -105,6 +105,14 @@ def test_app_git_azure_devops(caplog: pytest.LogCaptureFixture):
 
     assert "app_label='app.kubernetes.io/name'" in caplog.text
     assert mocked_exporter.app_label == "app.kubernetes.io/name"
+    assert "hash_annotation_name='io.openshift.build.commit.id'" in caplog.text
+    assert mocked_exporter.hash_annotation_name == "io.openshift.build.commit.id"
+    assert (
+        "repo_url_annotation_name='io.openshift.build.source-location'" in caplog.text
+    )
+    assert (
+        mocked_exporter.repo_url_annotation_name == "io.openshift.build.source-location"
+    )
     assert "provider='git'" in caplog.text
     assert "git_provider='azure-devops'" in caplog.text
     assert isinstance(mocked_exporter, AzureDevOpsCommitCollector)
@@ -128,6 +136,8 @@ def test_app_git_with_all_options(caplog: pytest.LogCaptureFixture):
             "APP_LABEL": "custom",
             # TODO how to test?
             "PELORUS_DEFAULT_KEYWORD": "another",
+            "COMMIT_HASH_ANNOTATION": "annotation",
+            "COMMIT_REPO_URL_ANNOTATION": "repo url",
             "PROVIDER": "git",
             "GIT_PROVIDER": "azure-devops",
             "NAMESPACES": "test1",
@@ -139,6 +149,10 @@ def test_app_git_with_all_options(caplog: pytest.LogCaptureFixture):
 
     assert "app_label='custom'" in caplog.text
     assert mocked_exporter.app_label == "custom"
+    assert "hash_annotation_name='annotation'" in caplog.text
+    assert mocked_exporter.hash_annotation_name == "annotation"
+    assert "repo_url_annotation_name='repo url'" in caplog.text
+    assert mocked_exporter.repo_url_annotation_name == "repo url"
     assert "provider='git'" in caplog.text
     assert "git_provider='azure-devops'" in caplog.text
     assert isinstance(mocked_exporter, AzureDevOpsCommitCollector)

--- a/exporters/tests/test_exporters.py
+++ b/exporters/tests/test_exporters.py
@@ -53,6 +53,177 @@ def test_commitmetric_repos(url, repo_protocol, fqdn, project_name):
     assert metric.git_fqdn == fqdn
     #    assert metric.git_server == str(protocol + '://' + fqdn)
     assert metric.repo_project == project_name
+    assert metric.azure_project is None
+
+
+@pytest.mark.parametrize(
+    "url,repo_protocol,fqdn,project_name,azure_organization,azure_project",
+    [
+        (
+            "git@ssh.dev.azure.com:v3/organization/project/repository/",
+            "ssh",
+            "ssh.dev.azure.com:v3",
+            "repository",
+            "organization",
+            "project",
+        ),
+        (
+            "git@ssh.dev.azure.com:v3/Organization1Name/Project-Name/the-repository-name/",
+            "ssh",
+            "ssh.dev.azure.com:v3",
+            "the-repository-name",
+            "Organization1Name",
+            "Project-Name",
+        ),
+        (
+            "https://dev.azure.com/Organization1Name/Project-Name/_git/the-repository-name/",
+            "https",
+            "dev.azure.com",
+            "the-repository-name",
+            "Organization1Name",
+            "Project-Name",
+        ),
+        (
+            "https://enterprise.custom/Organization1Name/Project-Name/_git/the-repository-name/",
+            "https",
+            "enterprise.custom",
+            "the-repository-name",
+            "Organization1Name",
+            "Project-Name",
+        ),
+        (
+            "https://dev.azure.com/Organization/Project/_git/repository/",
+            "https",
+            "dev.azure.com",
+            "repository",
+            "Organization",
+            "Project",
+        ),
+        (
+            "https://dev.azure.com/organization/project/_git/repository/",
+            "https",
+            "dev.azure.com",
+            "repository",
+            "organization",
+            "project",
+        ),
+        (
+            "https://dev.azure.com:8080/organization/project/_git/repository/",
+            "https",
+            "dev.azure.com",
+            "repository",
+            "organization",
+            "project",
+        ),
+        (
+            "http://dev.azure.com:8080/organization/project/_git/repository/",
+            "http",
+            "dev.azure.com",
+            "repository",
+            "organization",
+            "project",
+        ),
+    ],
+)
+def test_commitmetric_azure_repos(
+    url, repo_protocol, fqdn, project_name, azure_organization, azure_project
+):
+    test_name = "pytest"
+    metric = CommitMetric(test_name)
+    assert metric.repo_url is None
+    assert metric.repo_protocol is None
+    assert metric.git_fqdn is None
+    assert metric.repo_group is None
+    assert metric.repo_project is None
+    assert metric.azure_project is None
+    metric.repo_url = url
+    assert metric.repo_url == url.strip("/")
+    assert metric.repo_protocol == repo_protocol
+    assert metric.repo_group == azure_organization
+    assert metric.git_fqdn == fqdn
+    assert f"{repo_protocol}://{fqdn}" in metric.git_server
+    assert metric.repo_project == project_name
+    assert metric.azure_project == azure_project
+
+
+@pytest.mark.parametrize(
+    "url,repo_protocol,fqdn,project_name,azure_organization,azure_project,user",
+    [
+        (
+            "https://User2@dev.azure.com/Organization1Name/Project-Name/_git/the-repository-name/",
+            "https",
+            "dev.azure.com",
+            "the-repository-name",
+            "Organization1Name",
+            "Project-Name",
+            "User2",
+        ),
+        (
+            "https://Bruce@enterprise.custom/Organization1Name/Project-Name/_git/the-repository-name/",
+            "https",
+            "enterprise.custom",
+            "the-repository-name",
+            "Organization1Name",
+            "Project-Name",
+            "Bruce",
+        ),
+        (
+            "https://User@dev.azure.com/Organization/Project/_git/repository/",
+            "https",
+            "dev.azure.com",
+            "repository",
+            "Organization",
+            "Project",
+            "User",
+        ),
+        (
+            "https://user@dev.azure.com/organization/project/_git/repository/",
+            "https",
+            "dev.azure.com",
+            "repository",
+            "organization",
+            "project",
+            "user",
+        ),
+        (
+            "https://user@dev.azure.com:8080/organization/project/_git/repository/",
+            "https",
+            "dev.azure.com",
+            "repository",
+            "organization",
+            "project",
+            "user",
+        ),
+        (
+            "http://user@dev.azure.com:8080/organization/project/_git/repository/",
+            "http",
+            "dev.azure.com",
+            "repository",
+            "organization",
+            "project",
+            "user",
+        ),
+    ],
+)
+def test_commitmetric_azure_repos_with_user(
+    url, repo_protocol, fqdn, project_name, azure_organization, azure_project, user
+):
+    test_name = "pytest"
+    metric = CommitMetric(test_name)
+    assert metric.repo_url is None
+    assert metric.repo_protocol is None
+    assert metric.git_fqdn is None
+    assert metric.repo_group is None
+    assert metric.repo_project is None
+    assert metric.azure_project is None
+    metric.repo_url = url
+    assert metric.repo_url == url.strip("/")
+    assert metric.repo_protocol == repo_protocol
+    assert metric.repo_group == azure_organization
+    assert metric.git_fqdn == fqdn
+    assert f"{repo_protocol}://{fqdn}" in metric.git_server
+    assert metric.repo_project == project_name
+    assert metric.azure_project == azure_project
 
 
 @pytest.mark.parametrize(

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -53,23 +53,16 @@ def setup_jira_collector(
     )
 
 
+@pytest.mark.parametrize("token", ["WIEds4uZHiCGnrtmgQPn9E7D", "fakepass"])
 @pytest.mark.integration
-def test_jira_connection():
-    collector = setup_jira_collector()
+def test_jira_error_connection(token: str):
+    collector = setup_jira_collector(token=token)
     with pytest.raises(JIRAError) as context_ex:
         collector._connect_to_jira()
     assert (
         "You are not authenticated. Authentication required to perform this operation."
         in str(context_ex.value)
     )
-
-
-@pytest.mark.integration
-def test_jira_pass_connection():
-    collector = setup_jira_collector(token="fakepass")
-    with pytest.raises(JIRAError) as context_ex:
-        collector._connect_to_jira()
-    assert "Basic authentication with passwords is deprecated" in str(context_ex.value)
 
 
 @pytest.mark.parametrize("projects", ["non_existing,Test,wrong_name", "Test"])

--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -100,14 +100,24 @@ function print_help() {
     printf "\tStartup:\n"
     printf "\t  -h\tprint this help\n"
     printf "\n\tOptions:\n"
-    printf "\t  -b\tbranch of the mig-demo-apps\n"
-    printf "\t  -f\tvalues filename passed to the Pelorus deployment from the todolist-mongo-go project\n"
-    printf "\t  -o\tgithub organization of the mig-demo-apps\n"
-    printf "\t  -d\tpath to virtualenv DIR\n"
-    printf "\t  -s\tpath to DIR with secrets files (used in prow CI)\n"
-    printf "\t  -e\tenable exporter <comma_list>. e.g. failure\n"
-    printf "\t  -t\tenable Thanos with s3 bucket\n"
+    printf "\t  -o\tgithub organization of the mig-demo-apps. By default, konveyor\n"
+    printf "\t  -b\tbranch of the mig-demo-apps. By default, master\n"
+    printf "\t  -f\tvalues filename of the mig-demo-apps. By default, values.yaml\n"
+    printf "\t  -d\tpath to Python virtual environment DIR. By default, the project's one\n"
+    printf "\t  -s\t(USED ONLY IN PROW CI) path to DIR with secrets files. For local runs, run 'export SECRET_NAME=VALUE'\n"
+    printf "\t  -t\tenable Thanos (long term persistent storage) tests with s3 bucket\n"
     printf "\t  -c\tpath to DIR with secrets files for s3 bucket\n"
+    printf "\t  -e\tenable exporter tests (comma separated). Examples:\n"
+    printf "\t\t  -e failure\n"
+    printf "\t\t  -e gitlab_committime,jira_committime\n"
+    printf "\t\tavailable options:\n"
+    printf "\t\t  failure - GitHub issue tracker - REQUIRES 'TOKEN=YOUR_GITHUB_TOKEN' SECRET\n"
+    printf "\t\t  gitlab_committime - GitLab git provider - REQUIRES 'GITLAB_API_TOKEN=YOUR_GITLAB_TOKEN' SECRET\n"
+    printf "\t\t  gitea_committime - Gitea git provider - REQUIRES 'GITEA_API_TOKEN=YOUR_GITEA_TOKEN' SECRET\n"
+    printf "\t\t  bitbucket_committime - Bitbucket git provider - REQUIRES 'BITBUCKET_API_USER=YOUR_BITBUCKET_USER' AND 'BITBUCKET_API_TOKEN=YOUR_BITBUCKET_TOKEN' SECRETS\n"
+    printf "\t\t  azure-devops-committime - Azure devops git provider - REQUIRES 'AZURE_DEVOPS_USER=YOUR_AZURE_DEVOPS_USER' AND 'AZURE_DEVOPS_TOKEN=YOUR_AZURE_DEVOPS_TOKEN' SECRETS\n"
+    printf "\t\t  jira_committime - Jira issue tracker - REQUIRES 'JIRA_USER=YOUR_JIRA_USER' AND 'JIRA_TOKEN=YOUR_JIRA_TOKEN' SECRETS\n"
+    printf "\t\t  jira_custom_committime - Jira issue tracker - REQUIRES 'JIRA_USER=YOUR_JIRA_USER' AND 'JIRA_TOKEN=YOUR_JIRA_TOKEN' SECRETS\n"
     # TODO add help
 
     exit 0
@@ -131,6 +141,7 @@ ENABLE_FAIL_EXP=false
 ENABLE_GITLAB_COM_EXP=false
 ENABLE_GITEA_COM_EXP=false
 ENABLE_BITBUCKET_COM_EXP=false
+ENABLE_AZURE_DEVOPS_COM_EXP=false
 ENABLE_JIRA_FAIL_EXP=false
 ENABLE_JIRA_CUSTOM_FAIL_EXP=false
 ENABLE_PAGERDUTY_FAIL_EXP=false
@@ -176,6 +187,7 @@ if [ -n "${enable_exporters}" ]; then
     echo ",$enable_exporters," | grep -q ",gitlab_committime," && ENABLE_GITLAB_COM_EXP=true && echo "Enabling Gitlab committime exporter"
     echo ",$enable_exporters," | grep -q ",gitea_committime," && ENABLE_GITEA_COM_EXP=true && echo "Enabling Gitea committime exporter"
     echo ",$enable_exporters," | grep -q ",bitbucket_committime," && ENABLE_BITBUCKET_COM_EXP=true && echo "Enabling Bitbucket committime exporter"
+    echo ",$enable_exporters," | grep -q ",azure-devops-committime," && ENABLE_AZURE_DEVOPS_COM_EXP=true && echo "Enabling Azure devops committime exporter"
     echo ",$enable_exporters," | grep -q ",jira_committime," && ENABLE_JIRA_FAIL_EXP=true && echo "Enabling JIRA failure exporter"
     echo ",$enable_exporters," | grep -q ",jira_custom_committime," && ENABLE_JIRA_CUSTOM_FAIL_EXP=true && echo "Enabling JIRA custom failure exporter"
     echo ",$enable_exporters," | grep -q ",pagerduty_failure," && ENABLE_PAGERDUTY_FAIL_EXP=true && echo "Enabling PagerDuty failure exporter"
@@ -470,6 +482,28 @@ if [ "${ENABLE_BITBUCKET_COM_EXP}" == true ]; then
     BINARY_BUILDS_NAMESPACES+=("${build_ns}")
     build_uri="https://bitbucket.org/michalpryc/pelorus-bitbucket"
     build_hash="e2c4ef00468dfc10aad1bd2d4c9d470160a7f471"
+    "${BINARY_BUILD_SCRIPT}" -n "${build_ns}" -b "${build_ns}-todolist" -u "${build_uri}" -s "${build_hash}"
+fi
+
+# enable Azure devops committime exporter
+if [ "${ENABLE_AZURE_DEVOPS_COM_EXP}" == true ]; then
+    secret_configured=$(create_k8s_secret azure-devops-secret AZURE_DEVOPS_TOKEN AZURE_DEVOPS_USER)
+    secret_exit=$?
+    echo "${secret_configured}"
+    if [[ $secret_exit != 0 ]]; then
+        exit 1
+    fi
+    # uncomment the Azure devops committime exporter in ci_values.yaml
+    if [[ "$secret_configured" == *true ]]; then
+        sed -i.bak "s/#azure-devops-committime@//g" "${DWN_DIR}/ci_values.yaml"
+        echo "The pelorus Azure devops committime exporter has been enabled"
+    fi
+
+    # namespace must match one from ci_values.yaml
+    build_ns="azure-devops-binary"
+    BINARY_BUILDS_NAMESPACES+=("${build_ns}")
+    build_uri="https://dev.azure.com/matews1943/test-pelorus/_git/test-pelorus"
+    build_hash="5b65e1230f9df517bb38979f8e7743928d715973"
     "${BINARY_BUILD_SCRIPT}" -n "${build_ns}" -b "${build_ns}-todolist" -u "${build_uri}" -s "${build_hash}"
 fi
 


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Fixes Azure devops URL parser.

## Linked Issues

resolves #898
resolves #902
related to #899 

## Testing Instructions

Use committime with data comming from `https://dev.azure.com/{organization}/{project}/_git/{repository}` (or custom enterprise URL, instead of  `dev.azure.com`) and using [`GIT_API`](https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/ExporterCommittime/#git_api) as `dev.azure.com` or `dev.azure.com/{organization}`.

- [x] provide exporter test image
- [x] test with `https://YOUR_USER@dev.azure.com/YOUR_ORG/YOUR_PROJECT/_git/YOUR_REPO`
- [x] test with `git@ssh.dev.azure.com:v3/YOUR_ORG/YOUR_PROJECT/YOUR_REPO`

### Example

To run e2e tests, run
```
./scripts/run-pelorus-e2e-tests -o mateusoliveira43 -b feat/azure-devops-test -e azure-devops-committime
```

To create test application, run
```
oc create namespace test-azure

oc create secret generic test-azure-secret --from-literal=password=YOUR_PERSONAL_ACCESS_TOKEN --type=kubernetes.io/basic-auth -n test-azure

oc secrets link builder test-azure-secret -n test-azure

oc new-app python:3.9~https://dev.azure.com/YOUR_ORG/YOUR_PROJECT/_git/YOUR_REPO \
--source-secret=test-azure-secret --strategy=docker \
-n test-azure -l app.kubernetes.io/name=test-azure
```
Create an Pelorus instance with
```yaml
kind: Pelorus
apiVersion: charts.pelorus.konveyor.io/v1alpha1
metadata:
  name: test-azure
  namespace: pelorus
spec:
  exporters:
    global: {}
    instances:
      - app_name: committime-exporter
        enabled: true
        exporter_type: committime
        image_name: quay.io/msouzaol/pelorus-exporter:latest
        extraEnv:
          - name: GIT_PROVIDER
            value: azure-devops
          - name: TOKEN
            value: YOUR_PERSONAL_ACCESS_TOKEN 
          - name: API_USER
            value: YOUR_USER
          - name: NAMESPACES
            value: test-azure
          - name: LOG_LEVEL
            value: DEBUG
      - app_name: deploy
        enabled: true
        exporter_type: deploytime
        extraEnv:
          - name: NAMESPACES
            value: test-azure
```
To delete test application, run
```
oc delete all -l app.kubernetes.io/name=test-azure -n test-azure

oc delete secret test-azure-secret -n test-azure
```