### PR TITLE
fix: PagerDuty e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,11 @@ mockoon-tests: $(PELORUS_VENV)
 .PHONY: e2e-tests e2e-tests-scenario-1 e2e-tests-scenario-1
 e2e-tests: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/run-pelorus-e2e-tests -o konveyor -e failure,gitlab_committime,gitea_committime,bitbucket_committime,jira_committime,jira_custom_committime -t
+	./scripts/run-pelorus-e2e-tests -o konveyor -a -t
 
 e2e-tests-scenario-1: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/run-pelorus-e2e-tests -f "periodic/quay_images_latest.yaml" -o konveyor -e failure,gitlab_committime,gitea_committime,bitbucket_committime,jira_committime,jira_custom_committime -t
+	./scripts/run-pelorus-e2e-tests -f "periodic/quay_images_latest.yaml" -o konveyor -a -t
 
 e2e-tests-scenario-2: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -617,18 +617,19 @@ export BITBUCKET_API_USER=<YOUR_BITBUCKET_USER>
 export BITBUCKET_API_TOKEN=<YOUR_BITBUCKET_TOKEN>
 export JIRA_USER=<YOUR_JIRA_USER>
 export JIRA_TOKEN=<YOUR_JIRA_TOKEN>
+export PAGER_DUTY_TOKEN=<YOUR_PAGER_DUTY_TOKEN>
 ```
 
 Then, log in to your OpenShift cluster and **ENSURE** your pelorus namespace does not exist (if it exist, you can delete it running `oc delete namespace pelorus`), and run
 ```
 make e2e-tests
 ```
-which is an alias to `./scripts/run-pelorus-e2e-tests -o konveyor -e failure,gitlab_committime,gitea_committime,bitbucket_committime,jira_committime,jira_custom_committime -t`
+which is an alias to `./scripts/run-pelorus-e2e-tests -o konveyor -a -t`
 
 To run e2e-tests from current branch, first create a PR in Pelorus project for it and export the necessary environment variables to run the script, by running
-```
+```shell
 export REPO_NAME=pelorus
-export PULL_NUMBER=THE_PR_NUMBER
+export PULL_NUMBER=<THE_PR_NUMBER>
 ```
 
 For more information, run

--- a/docs/UpstreamSupport.md
+++ b/docs/UpstreamSupport.md
@@ -32,7 +32,8 @@ with out CI integration will have an associated Github issue in CI status and St
 |:--------|:--------------|:-------------|
 | Jira  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-jira+ )   | [Integration CI present](#integration-in-ci) |
 | GitHub  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-github+)   | [Integration CI present](#integration-in-ci) |
-| Service Now | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-servicenow+) | [todo](https://github.com/dora-metrics/pelorus/issues/573)
+| Service Now | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-servicenow+) | [todo](https://github.com/dora-metrics/pelorus/issues/573) |
+| PagerDuty | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-pagerduty+) | [Integration CI present](#integration-in-ci) |
 
 ### **Deploytime Exporter**
 |Backend |Known issues        |CI status    |

--- a/exporters/tests/test_failure_exporter_app.py
+++ b/exporters/tests/test_failure_exporter_app.py
@@ -57,7 +57,7 @@ def test_app_pagerduty_with_required_options(caplog: pytest.LogCaptureFixture):
     )
 
     captured_logs = caplog.record_tuples
-    # 9 informational, 5 resolution, 57 creation
-    assert len(captured_logs) == 71
+    # 9 informational, 5 resolution, 58 creation
+    assert len(captured_logs) == 72
     # number of error logs
     assert len([record for record in captured_logs if record[1] == 40]) == 0

--- a/exporters/tests/test_failure_exporter_pager_duty.py
+++ b/exporters/tests/test_failure_exporter_pager_duty.py
@@ -24,13 +24,13 @@ from tests import run_prometheus_register
 
 PAGER_DUTY_TOKEN = os.environ.get("PAGER_DUTY_TOKEN")
 NUMBER_OF_INCIDENTS = {
-    "null": 41,
+    "null": 42,
     "P1": 16,
     "P2": 0,
     "P3": 0,
     "P4": 0,
     "P5": 0,
-    "high": 46,
+    "high": 47,
     "low": 11,
 }
 
@@ -59,8 +59,8 @@ def test_pager_duty_search():
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 57
-    assert len([issue for issue in issues if issue.resolutiondate is None]) == 52
+    assert len(issues) == 58
+    assert len([issue for issue in issues if issue.resolutiondate is None]) == 53
     assert len([issue for issue in issues if issue.resolutiondate]) == 5
 
 

--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -107,7 +107,8 @@ function print_help() {
     printf "\t  -s\t(USED ONLY IN PROW CI) path to DIR with secrets files. For local runs, run 'export SECRET_NAME=VALUE'\n"
     printf "\t  -t\tenable Thanos (long term persistent storage) tests with s3 bucket\n"
     printf "\t  -c\tpath to DIR with secrets files for s3 bucket\n"
-    printf "\t  -e\tenable exporter tests (comma separated). Examples:\n"
+    printf "\t  -a\tenable all exporter tests \n"
+    printf "\t  -e\tenable selected exporter tests (comma separated). Examples:\n"
     printf "\t\t  -e failure\n"
     printf "\t\t  -e gitlab_committime,jira_committime\n"
     printf "\t\tavailable options:\n"
@@ -118,7 +119,7 @@ function print_help() {
     printf "\t\t  azure-devops-committime - Azure devops git provider - REQUIRES 'AZURE_DEVOPS_USER=YOUR_AZURE_DEVOPS_USER' AND 'AZURE_DEVOPS_TOKEN=YOUR_AZURE_DEVOPS_TOKEN' SECRETS\n"
     printf "\t\t  jira_committime - Jira issue tracker - REQUIRES 'JIRA_USER=YOUR_JIRA_USER' AND 'JIRA_TOKEN=YOUR_JIRA_TOKEN' SECRETS\n"
     printf "\t\t  jira_custom_committime - Jira issue tracker - REQUIRES 'JIRA_USER=YOUR_JIRA_USER' AND 'JIRA_TOKEN=YOUR_JIRA_TOKEN' SECRETS\n"
-    # TODO add help
+    printf "\t\t  pagerduty_failure - PagerDuty issue tracker - REQUIRES 'PAGER_DUTY_TOKEN=YOUR_PAGER_DUTY_TOKEN' SECRET\n"
 
     exit 0
 }
@@ -146,11 +147,12 @@ ENABLE_JIRA_FAIL_EXP=false
 ENABLE_JIRA_CUSTOM_FAIL_EXP=false
 ENABLE_PAGERDUTY_FAIL_EXP=false
 ENABLE_THANOS=false
+ENABLE_ALL_EXPORTERS=false
 
 # Used for cleanup to ensure created binary builds can be safely deleted
 BINARY_BUILDS_NAMESPACES=()
 
-while getopts "h?b:d:s:o:f:e:tc:" option; do
+while getopts "h?b:d:s:o:f:ae:tc:" option; do
     case "$option" in
     h|\?) print_help;;
     b)    demo_branch=$OPTARG;;
@@ -159,6 +161,7 @@ while getopts "h?b:d:s:o:f:e:tc:" option; do
     d)    venv_dir=$OPTARG;;
     s)    secrets_dir=$OPTARG;;
     e)    enable_exporters=$OPTARG;;
+    a)    ENABLE_ALL_EXPORTERS=true;;
     t)    ENABLE_THANOS=true;;
     c)    s3_secrets_dir=$OPTARG;;
     esac
@@ -191,6 +194,17 @@ if [ -n "${enable_exporters}" ]; then
     echo ",$enable_exporters," | grep -q ",jira_committime," && ENABLE_JIRA_FAIL_EXP=true && echo "Enabling JIRA failure exporter"
     echo ",$enable_exporters," | grep -q ",jira_custom_committime," && ENABLE_JIRA_CUSTOM_FAIL_EXP=true && echo "Enabling JIRA custom failure exporter"
     echo ",$enable_exporters," | grep -q ",pagerduty_failure," && ENABLE_PAGERDUTY_FAIL_EXP=true && echo "Enabling PagerDuty failure exporter"
+fi
+
+if [ "${ENABLE_ALL_EXPORTERS}" == true ]; then
+    ENABLE_FAIL_EXP=true && echo "Enabling Failure exporter"
+    ENABLE_GITLAB_COM_EXP=true && echo "Enabling Gitlab committime exporter"
+    ENABLE_GITEA_COM_EXP=true && echo "Enabling Gitea committime exporter"
+    ENABLE_BITBUCKET_COM_EXP=true && echo "Enabling Bitbucket committime exporter"
+    # TODO ENABLE_AZURE_DEVOPS_COM_EXP=true && echo "Enabling Azure devops committime exporter"
+    ENABLE_JIRA_FAIL_EXP=true && echo "Enabling JIRA failure exporter"
+    ENABLE_JIRA_CUSTOM_FAIL_EXP=true && echo "Enabling JIRA custom failure exporter"
+    ENABLE_PAGERDUTY_FAIL_EXP=true && echo "Enabling PagerDuty failure exporter"
 fi
 
 if [ -z "${demo_branch}" ]; then


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Fix PagerDuty end to end (e2e) tests.

## Linked Issues

resolves #880

## Testing Instructions

- [x] Update command after PR in `konveyor/mig-demo-apps` is merged

To run end to end tests with PagerDuty, run
```
export PAGER_DUTY_TOKEN=YOUR_TOKEN
./scripts/run-pelorus-e2e-tests -e pagerduty_failure
```

To clean the environment afterwards, run
```
curl https://raw.githubusercontent.com/konveyor/mig-demo-apps/master/apps/todolist-mongo-go/mongo-persistent.yaml | oc delete -f -
helm uninstall pelorus --namespace pelorus
helm uninstall operators --namespace pelorus
```
