### PR TITLE
Build exporter images with the tag from updated _imagestream_from_image

### DIFF
--- a/.github/workflow_templates/build_push_exporters/action.yml
+++ b/.github/workflow_templates/build_push_exporters/action.yml
@@ -1,0 +1,53 @@
+name: build_push_exporters
+
+inputs:
+  image: 
+    required: true
+  builder_image:
+    required: true
+  s2i_log_level:
+    required: true
+  quay_imageregistry:
+    required: true
+  quay_imagenamespace:
+    required: true
+  quay_username:
+    required: true
+  quay_password:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set Image version
+      shell: bash
+      run: |
+        IMG_VER=$(grep quay.io charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml | grep -oP '(?<=default ")[^"]+')
+        echo "Image version: $IMG_VER"
+        echo "VERSION=$IMG_VER" >> $GITHUB_ENV
+
+    # Setup S2i and Build container image
+    - name: Setup and Build
+      id: build-exporter
+      uses: redhat-actions/s2i-build@v2
+      with:
+        image: ${{ inputs.image }}
+        path_context: 'exporters'
+        builder_image: ${{ inputs.builder_image }}
+        tags: latest ${{ github.sha }}
+        log_level: ${{ inputs.s2i_log_level }}
+
+    - name: Tag exporter image with additional version tag
+      shell: bash
+      run: |
+        docker tag ${{ steps.build-exporter.outputs.image }}:${{ github.sha }} ${{ steps.build-exporter.outputs.image }}:${{ env.VERSION }}
+
+    # Push Image to Quay registry
+    - name: Push To Quay Action
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-exporter.outputs.image }}
+        tags: ${{ steps.build-exporter.outputs.tags }} ${{ env.VERSION }}
+        registry: ${{ inputs.quay_imageregistry }}/${{ inputs.quay_imagenamespace }}
+        username: ${{ inputs.quay_username }}
+        password: ${{ inputs.quay_password }}

--- a/.github/workflows/build-pelorus.yml
+++ b/.github/workflows/build-pelorus.yml
@@ -7,156 +7,103 @@ on:
     paths:
       - 'exporters/**'
       - 'charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml'
+      - 'charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml'
       - '.github/workflows/build-pelorus.yml'
 
 env:
   builder_image: 'registry.access.redhat.com/ubi8/python-39'
   imageregistry: 'quay.io'
-  # default 'pelorus'
+  # Use 'pelorus' for release
   imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
-  latesttag: latest
   s2i_log_level: 2
 
 jobs:
-  build-committime:
-    runs-on: ubuntu-20.04
+  build-and-push-committime-image:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Setup S2i and Build container image
-      - name: Setup and Build
-        id: build-exporter
-        uses: redhat-actions/s2i-build@v2
+      - name: Build and push committime exporter
+        uses: "./.github/workflow_templates/build_push_exporters"
         with:
           image: 'pelorus-committime-exporter'
-          path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
-          tags: ${{ env.latesttag }} ${{ github.sha }}
-          log_level: ${{ env.s2i_log_level }}
-
-      # Push Image to Quay registry
-      - name: Push To Quay Action
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-exporter.outputs.image }}
-          tags: ${{ steps.build-exporter.outputs.tags }}
-          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          s2i_log_level: ${{ env.s2i_log_level }}
+          quay_imageregistry: ${{ env.imageregistry }}
+          quay_imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
+          quay_username: ${{ secrets.QUAY_USERNAME }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
 
 
-  build-deploytime:
-    runs-on: ubuntu-20.04
+  build-and-push-deploytime-image:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Setup S2i and Build container image
-      - name: Setup and Build
-        id: build-exporter
-        uses: redhat-actions/s2i-build@v2
+      - name: Build and push deploytime exporter
+        uses: "./.github/workflow_templates/build_push_exporters"
         with:
           image: 'pelorus-deploytime-exporter'
-          path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
-          tags: ${{ env.latesttag }} ${{ github.sha }}
-          log_level: ${{ env.s2i_log_level }}
+          s2i_log_level: ${{ env.s2i_log_level }}
+          quay_imageregistry: ${{ env.imageregistry }}
+          quay_imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
+          quay_username: ${{ secrets.QUAY_USERNAME }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
 
 
-      # Push Image to Quay registry
-      - name: Push To Quay Action
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-exporter.outputs.image }}
-          tags: ${{ steps.build-exporter.outputs.tags }}
-          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-
-  build-failure:
-    runs-on: ubuntu-20.04
+  build-and-push-failure-image:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Setup S2i and Build container image
-      - name: Setup and Build
-        id: build-exporter
-        uses: redhat-actions/s2i-build@v2
+      - name: Build and push failure exporter
+        uses: "./.github/workflow_templates/build_push_exporters"
         with:
           image: 'pelorus-failure-exporter'
-          path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
-          tags: ${{ env.latesttag }} ${{ github.sha }}
-          log_level: ${{ env.s2i_log_level }}
+          s2i_log_level: ${{ env.s2i_log_level }}
+          quay_imageregistry: ${{ env.imageregistry }}
+          quay_imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
+          quay_username: ${{ secrets.QUAY_USERNAME }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
 
 
-      # Push Image to Quay registry
-      - name: Push To Quay Action
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-exporter.outputs.image }}
-          tags: ${{ steps.build-exporter.outputs.tags }}
-          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-
-  build-releasetime:
-    runs-on: ubuntu-20.04
+  build-and-push-releasetime-image:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Setup S2i and Build container image
-      - name: Setup and Build
-        id: build-exporter
-        uses: redhat-actions/s2i-build@v2
+      - name: Build and push releasetime exporter
+        uses: "./.github/workflow_templates/build_push_exporters"
         with:
           image: 'pelorus-releasetime-exporter'
-          path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
-          tags: ${{ env.latesttag }} ${{ github.sha }}
-          log_level: ${{ env.s2i_log_level }}
+          s2i_log_level: ${{ env.s2i_log_level }}
+          quay_imageregistry: ${{ env.imageregistry }}
+          quay_imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
+          quay_username: ${{ secrets.QUAY_USERNAME }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
 
 
-      # Push Image to Quay registry
-      - name: Push To Quay Action
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-exporter.outputs.image }}
-          tags: ${{ steps.build-exporter.outputs.tags }}
-          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-
-  build-webhook:
-    runs-on: ubuntu-20.04
+  build-and-push-webhook-image:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Setup S2i and Build container image
-      - name: Setup and Build
-        id: build-exporter
-        uses: redhat-actions/s2i-build@v2
+      - name: Build and push webhook exporter
+        uses: "./.github/workflow_templates/build_push_exporters"
         with:
           image: 'pelorus-webhook-exporter'
-          path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
-          tags: ${{ env.latesttag }} ${{ github.sha }}
-          log_level: ${{ env.s2i_log_level }}
+          s2i_log_level: ${{ env.s2i_log_level }}
+          quay_imageregistry: ${{ env.imageregistry }}
+          quay_imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
+          quay_username: ${{ secrets.QUAY_USERNAME }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
 
-
-      # Push Image to Quay registry
-      - name: Push To Quay Action
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-exporter.outputs.image }}
-          tags: ${{ steps.build-exporter.outputs.tags }}
-          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
This allows to set proper tags whenever our chart points to a new tag.

The change moves some common action code to a template making less code duplication.