### PR TITLE
fix: Jira integration test

### DIFF
--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -57,12 +57,8 @@ def setup_jira_collector(
 @pytest.mark.integration
 def test_jira_error_connection(token: str):
     collector = setup_jira_collector(token=token)
-    with pytest.raises(JIRAError) as context_ex:
+    with pytest.raises(JIRAError):
         collector._connect_to_jira()
-    assert (
-        "You are not authenticated. Authentication required to perform this operation."
-        in str(context_ex.value)
-    )
 
 
 @pytest.mark.parametrize("projects", ["non_existing,Test,wrong_name", "Test"])


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Fix Jira integration test.

In the past weeks, Jira API was not consistent, giving different messages for using wrong password authentication. Because of this, I am removing the check of the error message from the test (but still testing with a error occurs).

## Linked Issues

resolves #902

## Testing Instructions

Run `make integration-tests`.
