### PR TITLE
feat: Azure Boards (Azure DevOps issue tracker) support

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -3,21 +3,21 @@ on:
   push:
     branches: [ master ]
     paths:
-      - 'pelorus-operator/**'
+      - 'exporters/**'
       - 'charts/**'
-      - 'lintconf.yaml'
+      - 'pelorus-operator/**'
       - '.github/workflows/chart-lint.yml'
-      - 'exporters/'
+      - 'lintconf.yaml'
       - 'Makefile'
 
   pull_request:
     branches: [ master ]
     paths:
-      - 'pelorus-operator/**'
+      - 'exporters/**'
       - 'charts/**'
-      - 'lintconf.yaml'
+      - 'pelorus-operator/**'
       - '.github/workflows/chart-lint.yml'
-      - 'exporters/'
+      - 'lintconf.yaml'
       - 'Makefile'
 
 jobs:

--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.2
+version: 2.0.10-rc.3

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.2
-digest: sha256:cb2f0ec027ba367dc1da78117295ff84bc0760a16aff5b68ef8e07c46ee09423
-generated: "2023-05-08T09:18:22.188410555-03:00"
+  version: 2.0.10-rc.3
+digest: sha256:aed1fee1f5b78fd3612981d3e64f51a893f0d0d9dd7035ad705dc7f4317dc7d9
+generated: "2023-05-10T10:08:53.649314959-03:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.2
+version: 2.0.10-rc.3
 
 dependencies:
   - name: exporters
-    version: 2.0.10-rc.2
+    version: 2.0.10-rc.3
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.2
+version: 2.0.10-rc.3

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.2" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.3" }}
             {{- end }}
 
             {{- if .extraEnv }}

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.2" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.3" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/docs/GettingStarted/Overview.md
+++ b/docs/GettingStarted/Overview.md
@@ -60,5 +60,6 @@ Open an [issue](https://github.com/dora-metrics/pelorus/issues/new?assignees=&la
 - GitHub :simple-github:
 - ServiceNow
 - PagerDuty :simple-pagerduty:
+- Azure DevOps :simple-azuredevops:
 
 </font>

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -64,6 +64,8 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 | [GITHUB_ISSUE_LABEL](#github_issue_label) | no | bug |
 | [PAGERDUTY_URGENCY](#pagerduty_urgency) | no | - |
 | [PAGERDUTY_PRIORITY](#pagerduty_priority) | no | - |
+| [AZURE_DEVOPS_TYPE](#azure_devops_type) | no | - |
+| [AZURE_DEVOPS_PRIORITY](#azure_devops_priority) | no | - |
 
 ###### PROVIDER
 
@@ -71,7 +73,7 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
     - **Default Value:** jira
 - **Type:** string
 
-: Set the Issue Tracker provider for the failure exporter. One of `jira`, `github`, `servicenow`, `pagerduty`.
+: Set the Issue Tracker provider for the failure exporter. One of `jira`, `github`, `servicenow`, `pagerduty`, `azure-devops`.
 
 ###### LOG_LEVEL
 
@@ -84,10 +86,10 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 ###### SERVER
 
 - **Required:** yes
-    - Only applicable for [PROVIDER](#provider) set to `jira` or `servicenow`
+    - Only applicable for [PROVIDER](#provider) set to `jira`, `servicenow` or `azure-devops`
 - **Type:** string
 
-: URL to the Jira or ServiceNow Server.
+: URL to the Jira, ServiceNow or Azure DevOps Server.
 
 ###### API_USER
 
@@ -109,7 +111,7 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 ###### APP_LABEL
 
 - **Required:** no
-    - Only applicable for [PROVIDER](#provider) set to `jira` or `github`
+    - Only applicable for [PROVIDER](#provider) set to `jira`, `github` or `azure-devops`
     - **Default Value:** app.kubernetes.io/name
 - **Type:** string
 
@@ -127,12 +129,14 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 ###### PROJECTS
 
 - **Required:** no
-    - Only applicable for [PROVIDER](#provider) set to `jira` or `github`
+    - Only applicable for [PROVIDER](#provider) set to `jira`, `github` or `azure-devops`
 - **Type:** comma separated list of strings
 
 : * Used by Jira to define which projects (keys or names) to monitor. Value is ignored if [JIRA_JQL_SEARCH_QUERY](#jira_jql_search_query) is defined.
 
 : * Used by GitHub to define which repositories' issues to monitor.
+
+: * Used by Azure DevOps to define which projects (by names) to monitor.
 
 ###### PELORUS_DEFAULT_KEYWORD
 
@@ -182,6 +186,22 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 - **Type:** string
 
 : Defines incidents priorities (comma separated) to be monitored. By default, monitors all priorities. To monitor incidents without priority, add **null** to this value.
+
+###### AZURE_DEVOPS_TYPE
+
+- **Required:** no
+    - Only applicable for [PROVIDER](#provider) set to `azure-devops`
+- **Type:** string
+
+: Defines work items types (comma separated) to be monitored. By default, monitors all types.
+
+###### AZURE_DEVOPS_PRIORITY
+
+- **Required:** no
+    - Only applicable for [PROVIDER](#provider) set to `azure-devops`
+- **Type:** int
+
+: Defines work items priorities (comma separated) to be monitored. By default, monitors all priorities.
 
 ## Configuring Jira
 
@@ -407,3 +427,29 @@ Failure Time Exporter(s) configured to work with PagerDuty can be easily adjuste
 * Monitor issues of only specific urgencies, using [PAGERDUTY_URGENCY](#pagerduty_urgency).
 
 * Monitor issues of only specific priorities, using [PAGERDUTY_PRIORITY](#pagerduty_priority).
+
+## Configuring Azure DevOps
+
+### Default workflow
+
+By default, Failure Time Exporter(s) configured to work with Azure DevOps will:
+
+* Monitor all work items in all projects that live in Azure DevOps URL passed through [SERVER](#server) (that the token passed through [TOKEN](#token) has access to).
+
+* Use the `app.kubernetes.io/name=app_name` work item tag, where **app_name** is the name of one of the applications being monitored.
+
+    > **NOTE:** Work items without such tag are collected with the application name set to **unknown**.
+
+* Work items will be considered resolved when their states change to `Done`.
+
+### Custom workflow
+
+Failure Time Exporter(s) configured to work with Azure DevOps can be easily adjusted to adapt to custom workflow(s), like:
+
+* Monitor work items of only specific projects within Azure DevOps URL, using [PROJECTS](#projects).
+
+* Use a custom work item tag for getting the name of one of the applications being monitored , using [APP_LABEL](#app_label).
+
+* Monitor work items of only specific type, using [AZURE_DEVOPS_TYPE](#azure_devops_type).
+
+* Monitor work items of only specific priorities, using [AZURE_DEVOPS_PRIORITY](#azure_devops_priority).

--- a/docs/UpstreamSupport.md
+++ b/docs/UpstreamSupport.md
@@ -34,6 +34,7 @@ with out CI integration will have an associated Github issue in CI status and St
 | GitHub  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-github+)   | [Integration CI present](#integration-in-ci) |
 | Service Now | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-servicenow+) | [todo](https://github.com/dora-metrics/pelorus/issues/573) |
 | PagerDuty | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-pagerduty+) | [Integration CI present](#integration-in-ci) |
+| Azure DevOps  | [status link](https://github.com/dora-metrics/pelorus/issues?q=is%3Aopen+label%3Afailure-exporter+label%3Abackend-azure-devops+)   | [Integration CI present](#integration-in-ci) |
 
 ### **Deploytime Exporter**
 |Backend |Known issues        |CI status    |

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -23,6 +23,7 @@ from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
 import pelorus
+from failure.collector_azure_devops import AzureDevOpsFailureCollector
 from failure.collector_base import AbstractFailureCollector
 from failure.collector_github import GithubFailureCollector
 from failure.collector_jira import JiraFailureCollector
@@ -35,6 +36,7 @@ PROVIDER_TYPES = {
     "github": GithubFailureCollector,
     "servicenow": ServiceNowFailureCollector,
     "pagerduty": PagerdutyFailureCollector,
+    "azure-devops": AzureDevOpsFailureCollector,
 }
 
 

--- a/exporters/failure/collector_azure_devops.py
+++ b/exporters/failure/collector_azure_devops.py
@@ -1,0 +1,206 @@
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import logging
+from typing import List
+
+from attrs import converters, define, field
+from azure.devops.connection import Connection
+from azure.devops.exceptions import AzureDevOpsServiceError
+from azure.devops.v6_0.work_item_tracking.models import Wiql, WorkItem
+from azure.devops.v6_0.work_item_tracking.work_item_tracking_client import (
+    WorkItemTrackingClient,
+)
+from msrest.authentication import BasicAuthentication
+
+from failure.collector_base import AbstractFailureCollector, TrackerIssue
+from pelorus.config import env_var_names, env_vars
+from pelorus.config.converters import comma_or_whitespace_separated, pass_through
+from pelorus.config.log import REDACT, log
+from pelorus.errors import FailureProviderAuthenticationError
+from pelorus.timeutil import parse_assuming_utc_with_fallback, second_precision
+from pelorus.utils import Url
+
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+_DATETIME_FORMAT_FALLBACK = "%Y-%m-%dT%H:%M:%SZ"
+
+
+@define(kw_only=True)
+class AzureDevOpsFailureCollector(AbstractFailureCollector):
+    """
+    Azure DevOps implementation of a FailureCollector
+    """
+
+    token: str = field(
+        metadata=env_vars(*env_var_names.TOKEN) | log(REDACT),
+        repr=False,
+    )
+
+    tracker_api: Url = field(
+        metadata=env_vars("SERVER"),
+        converter=converters.optional(pass_through(Url, Url.parse)),
+    )
+
+    projects: set[str] = field(
+        factory=set, converter=comma_or_whitespace_separated(set)
+    )
+
+    work_item_type: set[str] = field(
+        factory=set,
+        converter=comma_or_whitespace_separated(set),
+        metadata=env_vars("AZURE_DEVOPS_TYPE"),
+    )
+
+    work_item_priority: set[str] = field(
+        factory=set,
+        converter=comma_or_whitespace_separated(set),
+        metadata=env_vars("AZURE_DEVOPS_PRIORITY"),
+    )
+
+    def __attrs_post_init__(self):
+        try:
+            credentials = BasicAuthentication("", self.token)
+            connection = Connection(base_url=self.tracker_api.url, creds=credentials)
+            self.client: WorkItemTrackingClient = (
+                connection.clients_v6_0.get_work_item_tracking_client()
+            )
+        except AzureDevOpsServiceError as error:
+            if error.type_key == "UnauthorizedRequestException":
+                logging.error(FailureProviderAuthenticationError.auth_message)
+                raise FailureProviderAuthenticationError from error
+            logging.error(error.message)
+            raise error
+
+    def get_work_items(self) -> List[WorkItem]:
+        logging.info("Getting work items")
+
+        try:
+            query_string = "Select [System.Id] From WorkItems"
+            if self.work_item_type or self.work_item_priority:
+                query_filters = []
+                if self.work_item_type:
+                    query_type = "', '".join(self.work_item_type)
+                    query_filters.append(f"[System.WorkItemType] In ('{query_type}')")
+                if self.work_item_priority:
+                    query_priority = "', '".join(self.work_item_priority)
+                    query_filters.append(
+                        f"[Microsoft.VSTS.Common.Priority] In ('{query_priority}')"
+                    )
+                query_string += f" Where {' AND '.join(query_filters)}"
+
+            wiql = Wiql(query=query_string)
+            wiql_results = self.client.query_by_wiql(wiql).work_items
+            chunk_size = 200
+            wiql_chunk_results = [
+                wiql_results[index : index + chunk_size]  # noqa
+                for index in range(0, len(wiql_results), chunk_size)
+            ]
+            return [
+                work_item
+                for chunk in wiql_chunk_results
+                for work_item in self.client.get_work_items(
+                    ids=[str(result.id) for result in chunk],
+                    fields=[
+                        "System.Title",
+                        "System.WorkItemType",
+                        "System.CreatedDate",
+                        "System.TeamProject",
+                        "System.Tags",
+                        "Microsoft.VSTS.Common.ClosedDate",
+                        "Microsoft.VSTS.Common.Priority",
+                    ],
+                )
+            ]
+        except AzureDevOpsServiceError as error:
+            if error.type_key == "UnauthorizedRequestException":
+                logging.error(FailureProviderAuthenticationError.auth_message)
+                raise FailureProviderAuthenticationError from error
+            logging.error(error.message)
+            raise error
+        except Exception as error:
+            logging.error(error)  # pragma: no cover
+            raise  # pragma: no cover
+
+    def filter_by_project(self, project: str) -> bool:
+        if not self.projects:
+            return True
+        return project in self.projects
+
+    def get_app_name(self, work_item: WorkItem) -> str:
+        try:
+            labels: str = work_item.fields["System.Tags"]
+            labels = labels.split("; ")
+
+            label_text = self.app_label + "="
+
+            for label in labels:
+                if label_text in label:
+                    return label.replace(label_text, "")
+            return "unknown"
+        except KeyError:
+            return "unknown"
+
+    def search_issues(self) -> list[TrackerIssue]:
+        """
+        To maintain consistency, we call this method `search_issues`. An
+        `issue` in Azure DevOps is called `work item`.
+        """
+        production_work_items = []
+        for work_item in self.get_work_items():
+            if self.filter_by_project(work_item.fields["System.TeamProject"]):
+                created_at = work_item.fields["System.CreatedDate"]
+                work_item_id = work_item.id
+                title = work_item.fields["System.Title"]
+
+                created_tz = parse_assuming_utc_with_fallback(
+                    created_at, _DATETIME_FORMAT, _DATETIME_FORMAT_FALLBACK
+                )
+                created_ts = second_precision(created_tz).timestamp()
+
+                try:
+                    resolved_at = work_item.fields["Microsoft.VSTS.Common.ClosedDate"]
+                    resolution_tz = parse_assuming_utc_with_fallback(
+                        resolved_at, _DATETIME_FORMAT, _DATETIME_FORMAT_FALLBACK
+                    )
+                    resolution_ts = second_precision(resolution_tz).timestamp()
+
+                    logging.debug(
+                        "Found production incident closed: {}, {}: {}".format(
+                            resolved_at,
+                            work_item_id,
+                            title,
+                        )
+                    )
+                except KeyError:
+                    logging.debug(
+                        "Found production incident opened: {}, {}: {}".format(
+                            created_at,
+                            work_item_id,
+                            title,
+                        )
+                    )
+                    resolution_ts = None
+
+                tracker_issue = TrackerIssue(
+                    str(work_item_id),
+                    created_ts,
+                    resolution_ts,
+                    self.get_app_name(work_item),
+                )
+                production_work_items.append(tracker_issue)
+        if not production_work_items:
+            # TODO should be warning?
+            logging.debug("No issues were found")
+        return production_work_items

--- a/exporters/pelorus/timeutil.py
+++ b/exporters/pelorus/timeutil.py
@@ -36,6 +36,35 @@ def parse_assuming_utc(timestring: str, format: str) -> datetime:
         return parsed.replace(tzinfo=timezone.utc)
 
 
+def parse_assuming_utc_with_fallback(
+    timestring: str, format: str, format_fallback: str
+) -> datetime:
+    """
+    Parse timestring with fallback case.
+
+    Try to parse timestring (UTC only) with `format`, if it fails, try to parse
+    it again, using `format_fallback`.
+
+    Parameters
+    ----------
+    timestring : str
+        String to be parsed, in UTC format.
+    format : str
+        Default format.
+    format_fallback : str
+        Fallback format.
+
+    Returns
+    -------
+    datetime
+        Parsed timestring.
+    """
+    try:
+        return parse_assuming_utc(timestring, format)
+    except ValueError:
+        return parse_assuming_utc(timestring, format_fallback)
+
+
 def parse_tz_aware(timestring: str, format: str) -> datetime:
     """
     Parses a timestring that includes its timezone information.

--- a/exporters/tests/test_failure_exporter_app.py
+++ b/exporters/tests/test_failure_exporter_app.py
@@ -18,10 +18,12 @@ import os
 import pytest
 
 from failure.app import set_up
+from pelorus.config.loading import MissingConfigDataError
 from pelorus.errors import FailureProviderAuthenticationError
 from tests import MockExporter
 
 PAGER_DUTY_TOKEN = os.environ.get("PAGER_DUTY_TOKEN")
+AZURE_DEVOPS_TOKEN = os.environ.get("AZURE_DEVOPS_TOKEN")
 
 mocked_failure_exporter = MockExporter(set_up=set_up)
 
@@ -59,5 +61,50 @@ def test_app_pagerduty_with_required_options(caplog: pytest.LogCaptureFixture):
     captured_logs = caplog.record_tuples
     # 9 informational, 5 resolution, 58 creation
     assert len(captured_logs) == 72
+    # number of error logs
+    assert len([record for record in captured_logs if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_azure_devops_without_required_options(caplog: pytest.LogCaptureFixture):
+    with pytest.raises(MissingConfigDataError):
+        mocked_failure_exporter.run_app({"PROVIDER": "azure-devops"})
+
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 7
+
+
+@pytest.mark.integration
+def test_app_azure_devops_with_wrong_token(caplog: pytest.LogCaptureFixture):
+    with pytest.raises(FailureProviderAuthenticationError):
+        mocked_failure_exporter.run_app(
+            {
+                "PROVIDER": "azure-devops",
+                "TOKEN": "fake_token",
+                "SERVER": "dev.azure.com/matews1943",
+            }
+        )
+
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_app_azure_devops_with_required_options(caplog: pytest.LogCaptureFixture):
+    mocked_failure_exporter.run_app(
+        {
+            "PROVIDER": "azure-devops",
+            "TOKEN": AZURE_DEVOPS_TOKEN,
+            "SERVER": "dev.azure.com/matews1943",
+        }
+    )
+
+    captured_logs = caplog.record_tuples
+    # 10 informational, 3 resolution, 213 creation
+    assert len(captured_logs) == 226
     # number of error logs
     assert len([record for record in captured_logs if record[1] == 40]) == 0

--- a/exporters/tests/test_failure_exporter_azure_devops.py
+++ b/exporters/tests/test_failure_exporter_azure_devops.py
@@ -1,0 +1,234 @@
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import os
+from contextlib import nullcontext
+from typing import Optional
+
+import pytest
+
+from failure.collector_azure_devops import AzureDevOpsFailureCollector
+
+AZURE_DEVOPS_TOKEN = os.environ.get("AZURE_DEVOPS_TOKEN")
+NUMBER_OF_WORK_ITEMS = {
+    # priority
+    "1": 0,
+    "2": 212,
+    "3": 1,
+    "4": 0,
+    # type
+    "Epic": 3,
+    "Issue": 207,
+    "Task": 3,
+    # project
+    "todolist": 3,
+    "test-pelorus": 210,
+    # app_label
+    "app.kubernetes.io/name": 1,
+    "custom": 2,
+}
+
+
+def setup_azure_devops_collector(
+    token: str = "fake_token",
+    app_label: str = "app.kubernetes.io/name",
+    projects: Optional[str] = None,
+    work_item_type: Optional[str] = None,
+    work_item_priority: Optional[str] = None,
+) -> AzureDevOpsFailureCollector:
+    return AzureDevOpsFailureCollector(
+        token=token,
+        app_label=app_label,
+        projects=projects,
+        work_item_type=work_item_type,
+        work_item_priority=work_item_priority,
+        tracker_api="dev.azure.com/matews1943",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search():
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 213
+    assert len([issue for issue in issues if issue.resolutiondate is None]) == 210
+    assert len([issue for issue in issues if issue.resolutiondate]) == 3
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_multiple_filters():
+    collector = setup_azure_devops_collector(
+        AZURE_DEVOPS_TOKEN,
+        work_item_type="Issue,Task,wrong",
+        work_item_priority="1,3,87",
+        projects="todolist,test-pelorus,wrong",
+    )
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 1
+
+
+@pytest.mark.parametrize("_type", ["Epic", "Issue", "Task"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_type(_type: str):
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN, work_item_type=_type)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == NUMBER_OF_WORK_ITEMS[_type]
+
+
+@pytest.mark.parametrize("_type", ["wrong", "not_available"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_wrong_type(_type: str):
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN, work_item_type=_type)
+
+    with nullcontext() as context:
+        # TODO should break or at least warn user?
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 0
+
+
+@pytest.mark.parametrize("priority", ["1", "2", "3", "4"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_priority(priority: str):
+    collector = setup_azure_devops_collector(
+        AZURE_DEVOPS_TOKEN, work_item_priority=priority
+    )
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == NUMBER_OF_WORK_ITEMS[priority]
+
+
+@pytest.mark.parametrize("priority", ["5", "6"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_wrong_priority(priority: str):
+    collector = setup_azure_devops_collector(
+        AZURE_DEVOPS_TOKEN, work_item_priority=priority
+    )
+
+    with nullcontext() as context:
+        # TODO should break or at least warn user?
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 0
+
+
+@pytest.mark.parametrize("project", ["todolist", "test-pelorus"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_project(project: str):
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN, projects=project)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == NUMBER_OF_WORK_ITEMS[project]
+
+
+@pytest.mark.parametrize("project", ["wrong", "not_available"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_wrong_project(project: str):
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN, projects=project)
+
+    with nullcontext() as context:
+        # TODO should break or at least warn user?
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 0
+
+
+@pytest.mark.parametrize("app_label", ["app.kubernetes.io/name", "custom"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_app_label(app_label: str):
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN, app_label=app_label)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert (
+        len([issue for issue in issues if issue.app != "unknown"])
+        == NUMBER_OF_WORK_ITEMS[app_label]
+    )  # that has label
+
+
+@pytest.mark.parametrize("app_label", ["wrong", "not_available"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not AZURE_DEVOPS_TOKEN,
+    reason="No Azure DevOps token set, run export AZURE_DEVOPS_TOKEN=token",
+)
+def test_azure_devops_search_with_wrong_app_label(app_label: str):
+    collector = setup_azure_devops_collector(AZURE_DEVOPS_TOKEN, app_label=app_label)
+
+    with nullcontext() as context:
+        # TODO should break or at least warn user?
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len([issue for issue in issues if issue.app != "unknown"]) == 0

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.7-rc.2
+VERSION ?= 0.0.7-rc.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -46,8 +46,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.2
-    createdAt: "2023-05-08T12:23:29Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.3
+    createdAt: "2023-05-10T13:10:45Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.7-rc.2
+  name: pelorus-operator.v0.0.7-rc.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -208,12 +208,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - '*'
-        - apiGroups:
           - ""
           resources:
           - configmaps
@@ -255,6 +249,12 @@ spec:
           - prometheuses
           - prometheusrules
           - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
           verbs:
           - '*'
         - apiGroups:
@@ -406,7 +406,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.2
+                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -508,7 +508,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.7-rc.2
+  version: 0.0.7-rc.3
   replaces: pelorus-operator.v0.0.6
   skips:
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.7-rc.2
+  newTag: 0.0.7-rc.3

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.2
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.3
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,12 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "route.openshift.io"
-  resources:
-  - "routes"
-- verbs:
-  - "*"
-  apiGroups:
   - ""
   resources:
   - "configmaps"
@@ -102,5 +96,11 @@ rules:
   - "prometheuses"
   - "prometheusrules"
   - "servicemonitors"
+- verbs:
+  - "*"
+  apiGroups:
+  - "route.openshift.io"
+  resources:
+  - "routes"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.2
-digest: sha256:cb2f0ec027ba367dc1da78117295ff84bc0760a16aff5b68ef8e07c46ee09423
-generated: "2023-05-08T09:23:25.371748046-03:00"
+  version: 2.0.10-rc.3
+digest: sha256:aed1fee1f5b78fd3612981d3e64f51a893f0d0d9dd7035ad705dc7f4317dc7d9
+generated: "2023-05-10T10:10:40.377683431-03:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.2
+  version: 2.0.10-rc.3
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.10-rc.2
+version: 2.0.10-rc.3

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.2
+version: 2.0.10-rc.3

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.2" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.3" }}
             {{- end }}
 
             {{- if .extraEnv }}

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.2" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.3" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Add Pelorus support for [Azure Boards](https://learn.microsoft.com/en-us/azure/devops/boards/get-started/what-is-azure-boards?view=azure-devops) (Azure DevOps issue tracker). About Azure Boards:

- An issue is called **work item** in it
- work items allows adding **tags**, which can work as labels
- work items have 3 states: **To Do**, **Doing** and **Done**. It is considered resolved when it status changes to Done
- For filtering, in addition to tags, we can use **type** (by default, task, issue or epic, but I think user can create custom ones) and priority (1, 2, 3 or 4). Also, projects can be used
- For further filtering, reason, boards and sprints could be used perhaps, but seems too much. Also, `Microsoft.VSTS.Common.Severity` and `Microsoft.VSTS.Common.Risk` were considered, but were not being used by the tests

Options available for new provider

| Variable | Required 
|----------|----------|
| PROVIDER| yes |
| LOG_LEVEL | no |
| SERVER| yes |
| TOKEN | yes |
| APP_LABEL | no |
| PROJECTS | no |
| PELORUS_DEFAULT_KEYWORD | no |
| AZURE_DEVOPS_TYPE | no |
| AZURE_DEVOPS_PRIORITY | no |

## Linked Issues

resolves #915
depends on #919

## Testing Instructions

### Test with CURL

To get work items ids, run
```
curl --header "Content-Type: application/json" \
  --request POST \
  --data '{"query": "Select [System.Id] From WorkItems"}' \
  -u :YOUR_TOKEN 'https://dev.azure.com/YOUR_ORG/_apis/wit/wiql?api-version=7.0' | jq
```

To get work items by ids, run
```
curl -u :YOUR_TOKEN \
  'https://dev.azure.com/YOUR_ORG/_apis/wit/workitems?ids=1,2,3,4,5,6,7,8,9&fields=System.Title,System.WorkItemType,System.CreatedDate,System.TeamProject,System.Tags,Microsoft.VSTS.Common.ClosedDate,Microsoft.VSTS.Common.Priority&api-version=7.0' | jq
```

The result should be similar to
```json
{
  "count": 9,
  "value": [
    ...
    {
      "id": 9, // Required
      "rev": 3,
      "fields": {
        "System.TeamProject": "test-pelorus", // Filtering : PROJECTS
        "System.WorkItemType": "Task", // Filtering : AZURE_DEVOPS_TYPE
        "System.CreatedDate": "2023-04-04T12:56:21.71Z", // Required
        "System.Title": "test resolution task", // Required
        "Microsoft.VSTS.Common.ClosedDate": "2023-04-04T12:57:50.41Z", // Required
        "Microsoft.VSTS.Common.Priority": 3, // Filtering : AZURE_DEVOPS_PRIORITY
        "System.Tags": "app.kubernetes.io/name=test; custom" // Required/Filtering : APP_LABEL
      },
      "url": "https://dev.azure.com/YOUR_ORG/_apis/wit/workItems/9"
    }
  ]
}
```

### e2e tests

- [x] update command after mig-demo-apps is merged https://github.com/konveyor/mig-demo-apps/pull/100

```
export REPO_NAME=pelorus
export PULL_NUMBER=925
export AZURE_DEVOPS_TOKEN=<YOUR_TOKEN>
./scripts/run-pelorus-e2e-tests.sh -e azure-devops_failure
```

### OpenShift tests

Create an instance with
```yaml
exporters:
    instances:
      - app_name: test-azure-boards
        enabled: true
        exporter_type: failure
        extraEnv:
          - name: PROVIDER
            value: azure-devops
          - name: SERVER
            value: YOUR_SERVER
          - name: TOKEN
            value: YOUR_TOKEN
        source_ref: feat/azure-boards
        source_url: 'https://github.com/mateusoliveira43/pelorus'
```

or without `source_ref` and `source_url` using the test image commented by github-actions[bot].