### PR TITLE
Add secret to secure payload for the webhook exporter

### DIFF
--- a/exporters/tests/test_pelorus_webhook.py
+++ b/exporters/tests/test_pelorus_webhook.py
@@ -18,6 +18,7 @@
 import json
 from http import HTTPStatus
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -65,26 +66,199 @@ def test_pelorus_webhook_no_headers(webhook_data_payload):
         ("webhook_pelorus_failure_resolved.json", "failure"),
     ],
 )
-def test_pelorus_webhook_post_data(webhook_data_payload, event_type):
+def test_pelorus_webhook_post_data_no_secret(webhook_data_payload, event_type):
     """
     Proper post data for different metrics.
+    No Secret configured.
     """
 
     headers_data["X-Pelorus-Event"] = event_type
 
     load_plugins()
 
-    webhook_response = client.post(
-        "/pelorus/webhook",
-        json=webhook_data_payload,
-        headers=headers_data,
-    )
+    with patch("webhook.app._get_hash_token") as mocked_get_hash:
+        mocked_get_hash.return_value = None
 
-    assert webhook_response.status_code == HTTPStatus.ACCEPTED
-    assert (
-        webhook_response.text
-        == '{"http_response":"Webhook Received","http_response_code":200}'
-    )
+        webhook_response = client.post(
+            "/pelorus/webhook",
+            json=webhook_data_payload,
+            headers=headers_data,
+        )
+
+        assert webhook_response.status_code == HTTPStatus.ACCEPTED
+        assert (
+            webhook_response.text
+            == '{"http_response":"Webhook Received","http_response_code":200}'
+        )
+
+
+@pytest.mark.parametrize(
+    "post_request_json_file, event_type, hash_signature",
+    [
+        (
+            "webhook_pelorus_committime.json",
+            "committime",
+            "sha256=1ce994968588a4d69f8732b1cde8c1d3581b38ce7bd97275ed9b0f61a1f2fc78",
+        ),
+    ],
+)
+def test_pelorus_webhook_post_data_wrong_x_signature_mismatch(
+    webhook_data_payload, event_type, hash_signature
+):
+    """
+    Proper post data for different metrics.
+    Secret token is configured and expected to be sent together with the payload.
+    SHA256 sent by the sender is in proper format, however wrongly calculated (mismatch)
+    """
+
+    headers_data["X-Pelorus-Event"] = event_type
+    headers_data["X-Hub-Signature-256"] = hash_signature
+
+    load_plugins()
+
+    with patch("webhook.app._get_hash_token") as mocked_get_hash:
+        mocked_get_hash.return_value = "My Secret Token"
+
+        webhook_response = client.post(
+            "/pelorus/webhook",
+            json=webhook_data_payload,
+            headers=headers_data,
+        )
+
+        assert webhook_response.status_code == HTTPStatus.BAD_REQUEST
+        assert webhook_response.text == '{"detail":"Invalid signature."}'
+
+
+@pytest.mark.parametrize(
+    "post_request_json_file, event_type, hash_signature",
+    [
+        (
+            "webhook_pelorus_committime.json",
+            "committime",
+            "sha256=1ce994968588a4d69f8732b1cde8c1d3581b38ce7bd97275ed9b0f61a1f2fcxx",
+        ),
+        (
+            "webhook_pelorus_committime.json",
+            "committime",
+            "bba6199207705f85437a94348b9e4dcc17ee66f81a754ec72c3f36b6808a534f",
+        ),
+        ("webhook_pelorus_committime.json", "committime", "improper"),
+    ],
+)
+def test_pelorus_webhook_post_data_wrong_x_signature_format(
+    webhook_data_payload, event_type, hash_signature
+):
+    """
+    Proper post data for different metrics.
+    Secret token is configured and expected to be sent together with the payload.
+    SHA256 sent by the sender is in wrong format
+    """
+
+    headers_data["X-Pelorus-Event"] = event_type
+    headers_data["X-Hub-Signature-256"] = hash_signature
+
+    load_plugins()
+
+    with patch("webhook.app._get_hash_token") as mocked_get_hash:
+        mocked_get_hash.return_value = "My Secret Token"
+
+        webhook_response = client.post(
+            "/pelorus/webhook",
+            json=webhook_data_payload,
+            headers=headers_data,
+        )
+
+        assert webhook_response.status_code == HTTPStatus.BAD_REQUEST
+        assert webhook_response.text == '{"detail":"Improper headers."}'
+
+
+@pytest.mark.parametrize(
+    "post_request_json_file, event_type",
+    [
+        ("webhook_pelorus_committime.json", "committime"),
+    ],
+)
+def test_pelorus_webhook_post_data_missing_x_signature(
+    webhook_data_payload, event_type
+):
+    """
+    The webhook configured to share "My Secret Token", however
+    sender do not include X-Hub-Signature-256 in the Header of the POST method
+    """
+
+    headers_data["X-Pelorus-Event"] = event_type
+
+    load_plugins()
+
+    with patch("webhook.app._get_hash_token") as mocked_get_hash:
+        mocked_get_hash.return_value = "My Secret Token"
+
+        webhook_response = client.post(
+            "/pelorus/webhook",
+            json=webhook_data_payload,
+            headers=headers_data,
+        )
+
+        assert webhook_response.status_code == HTTPStatus.BAD_REQUEST
+        assert webhook_response.text == '{"detail":"Improper headers."}'
+
+
+@pytest.mark.parametrize(
+    "post_request_json_file, event_type, hash_signature",
+    [
+        (
+            "webhook_pelorus_committime.json",
+            "committime",
+            "sha256=3ce994968588a4d69f8732b1cde8c1d3581b38ce7bd97275ed9b0f61a1f2fc78",
+        ),
+        (
+            "webhook_pelorus_deploytime.json",
+            "deploytime",
+            "sha256=bba6199207705f85437a94348b9e4dcc17ee66f81a754ec72c3f36b6808a534f",
+        ),
+        (
+            "webhook_pelorus_failure_created.json",
+            "failure",
+            "sha256=44082cdb4d7b95c11e401d44cec949918b472e9a44becb5b7ee7d2b21a6428f0",
+        ),
+        (
+            "webhook_pelorus_failure_resolved.json",
+            "failure",
+            "sha256=2b7d9028fef8110ceff83492e35c938f8ac9b7851bc2307d8bd5ba7f3c3c48f9",
+        ),
+    ],
+)
+def test_pelorus_webhook_post_data_x_signature_secret(
+    webhook_data_payload, event_type, hash_signature
+):
+    """
+    Proper post data for different metrics.
+    Secret token is configured and expected to be sent together with the payload.
+    sha256 for the relevant images calculated using (example for webhook_pelorus_failure_resolved):
+      $ jq -c "" ./webhook_pelorus_failure_resolved.json | openssl dgst -sha256 -hmac "My Secret Token"
+      SHA2-256(stdin)= 2b7d9028fef8110ceff83492e35c938f8ac9b7851bc2307d8bd5ba7f3c3c48f9
+
+    """
+
+    headers_data["X-Pelorus-Event"] = event_type
+    headers_data["X-Hub-Signature-256"] = hash_signature
+
+    load_plugins()
+
+    with patch("webhook.app._get_hash_token") as mocked_get_hash:
+        mocked_get_hash.return_value = "My Secret Token"
+
+        webhook_response = client.post(
+            "/pelorus/webhook",
+            json=webhook_data_payload,
+            headers=headers_data,
+        )
+
+        assert webhook_response.status_code == HTTPStatus.ACCEPTED
+        assert (
+            webhook_response.text
+            == '{"http_response":"Webhook Received","http_response_code":200}'
+        )
 
 
 @pytest.mark.parametrize("post_request_json_file", ["webhook_pelorus_committime.json"])

--- a/exporters/webhook/plugins/pelorus_handler_base.py
+++ b/exporters/webhook/plugins/pelorus_handler_base.py
@@ -96,15 +96,20 @@ class PelorusWebhookPlugin(ABC):
     Attributes:
         handshake_headers: (Headers): Headers that are received by the webhook.
         request: (Request): The request object associated with the webhook.
+        secret: Optional[str]: Webhook secret, if provided header must contain
+                               X-Hub-Signature-256 signature.
     """
 
     user_agent_str = None
 
-    def __init__(self, handshake_headers: Headers, request: Request) -> None:
+    def __init__(
+        self, handshake_headers: Headers, request: Request, secret: Optional[str] = None
+    ) -> None:
         super().__init__()
         self.headers = handshake_headers
         self.request = request
         self.payload_data = None
+        self.secret = secret
 
     @abstractmethod
     async def _handshake(self, headers: Headers) -> Awaitable[bool]:


### PR DESCRIPTION
Adds option to configure webhook exporter to share SECRET_TOKEN to validate payload integrity.

With the webhook configured to use SECRET_TOKEN the sender is obligated to calculate the SHA256 hash of the payload and include that hash as a header during POST method, otherwise the payload will not be received and recorded by the webhook.

resolves #922 

## Testing Instructions

1. Deploy Pelorus with the webhook exporter that does have SECRET_TOKEN configured
2. Send sample data using curl to the webhook exporter endpoint as described in the examples section of the documentation

Alternatively use python to start the webhook exporter previously exporting SECRET_TOKEN:

```shell
$ make dev-env
$ source .venv/bin/activate
$ export SECRET_TOKEN="My Secret Token"
$ python exporters/webhook/app.py
```

And sent from another shell sharing the same SECRET_TOKEN the payload as described in the documentation to the `http://localhost:8080/pelorus/webhook` endpoint. 

```shell
$ cd exporters/tests/data
$ export SECRET_TOKEN="My Secret Token"
$ SHA256_HASH_SIGNATURE=$(echo -n $(cat "./webhook_pelorus_committime.json") | openssl dgst -sha256 -hmac "${SECRET_TOKEN}"| cut -d ' ' -f 2)

# Validate if hash was correctly calculated
$ echo $SHA256_HASH_SIGNATURE
789c5630940ee8ede816709f6535cf576457e7b625b7b1c64ec01b8db358c6cc


$ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_committime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: committime"  -H "X-Hub-Signature-256: sha256=${SHA256_HASH_SIGNATURE}"
{"http_response":"Webhook Received","http_response_code":200}

# Try to send data with no 'X-Hub-Signature-256'
$ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_committime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: committime" 
{"detail":"Non existing signature."}

# Try to send data with wrong format signature
$ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_committime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: committime"  -H "X-Hub-Signature-256: sha256=fake_signature"
{"detail":"Improper headers."}

# Try to send data with mismatch signature
$ export SHA256_HASH_SIGNATURE=111111111111e8ede816709f6535cf576457e7b625b7b1c64ec01b8db358c6cc
$ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_committime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: committime"  -H "X-Hub-Signature-256: sha256=${SHA256_HASH_SIGNATURE}"
{"detail":"Invalid signature."}

# Try to calculate signature using jq:
$ SHA256_HASH_SIGNATURE=$(jq -c "" "./webhook_pelorus_committime.json" | openssl dgst -sha256 -hmac "${SECRET_TOKEN}"| cut -d ' ' -f 2)

$ echo $SHA256_HASH_SIGNATURE
3ce994968588a4d69f8732b1cde8c1d3581b38ce7bd97275ed9b0f61a1f2fc78

$ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_committime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: committime"  -H "X-Hub-Signature-256: sha256=${SHA256_HASH_SIGNATURE}"
{"http_response":"Webhook Received","http_response_code":200}
```

Review if the data is received by opening web page `http://localhost:8080/metrics`