### PR TITLE
Add the timestamp to the webhook exporter.

### DIFF
--- a/docs/GettingStarted/configuration/ExporterWebhook.md
+++ b/docs/GettingStarted/configuration/ExporterWebhook.md
@@ -90,7 +90,7 @@ For the Header X-Pelorus-Event: `deploytime`
 | `app`       | `string` | Monitored application name |
 | `image_sha` | `string` | Image SHA used for deployment. Must be prefixed with the `sha256:` followed by 64 characters of small letters and numbers |
 | `namespace` | `string` | OpenShift namespace to which application was deployed |
-| `timestamp` | `int`    | EPOCH timestamp representing event occurrence. Allowed format: `10 digit int`|
+| `timestamp` | `int`    | EPOCH timestamp representing event occurrence. Must be not older then 30min from now. Allowed format: `10 digit int`|
 
 ##### committime
 For the Header X-Pelorus-Event: `committime`
@@ -101,7 +101,7 @@ For the Header X-Pelorus-Event: `committime`
 | `commit_hash` | `string` | Source code GIT SHA-1 used to build the image represented by the `image_sha`. Must be either 7 or 40 characters long |
 | `image_sha`   | `string` | Image SHA used for deployment. Must be prefixed with the `sha256:` followed by 64 characters of small letters and numbers |
 | `namespace`   | `string` | OpenShift namespace to which application was deployed |
-| `timestamp`   | `int`    | EPOCH timestamp representing event occurrence. Allowed format: `10 digit int`|
+| `timestamp`   | `int`    | EPOCH timestamp representing event occurrence. Must be not older then 30min from now. Allowed format: `10 digit int`|
 
 ##### failure
 For the Header X-Pelorus-Event: `failure`
@@ -111,7 +111,7 @@ For the Header X-Pelorus-Event: `failure`
 | `app`           | `string` | Monitored application name |
 | `failure_id`    | `string` | Unique string representation of an failure  |
 | `failure_event` | `string` | Information about failure event. Allowed string values: `created` or `resolved` |
-| `timestamp`     | `int`    | EPOCH timestamp representing event occurrence. Allowed format: `10 digit int`|
+| `timestamp`     | `int`    | EPOCH timestamp representing event occurrence. Must be not older then 30min from now. Allowed format: `10 digit int`|
 
 
 ## Example usage
@@ -119,6 +119,8 @@ For the Header X-Pelorus-Event: `failure`
 ### Sending non-secure payload
 
 You can easily send a POST request using [Curl](https://curl.se) directly from the shell. You can store the payload data in a file or pass it as an argument to [Curl](https://curl.se). Below is an example of sending several requests to cover the lifecycle of an application:
+
+  > **NOTE:** To align with the nature of Prometheus, it is required that the event being sent to the webhook exporter should not have occurred more than 30 minutes prior to the time of sending.
 
 * Our application:
     * is named **`mongo-todolist`** in OpenShift.

--- a/exporters/tests/data/webhook_pelorus_committime.json
+++ b/exporters/tests/data/webhook_pelorus_committime.json
@@ -2,6 +2,5 @@
   "app": "mongo-todolist",
   "commit_hash": "5379bad65a3f83853a75aabec9e0e43c75fd18fc",
   "image_sha": "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
-  "namespace": "mongo-persistent",
-  "timestamp": 1557933657
+  "namespace": "mongo-persistent"
 }

--- a/exporters/tests/data/webhook_pelorus_deploytime.json
+++ b/exporters/tests/data/webhook_pelorus_deploytime.json
@@ -1,6 +1,5 @@
 {
   "app": "mongo-todolist",
   "image_sha": "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
-  "namespace": "mongo-persistent",
-  "timestamp": 1557933657
+  "namespace": "mongo-persistent"
 }

--- a/exporters/tests/data/webhook_pelorus_failure_created.json
+++ b/exporters/tests/data/webhook_pelorus_failure_created.json
@@ -1,6 +1,5 @@
 {
   "app": "mongo-todolist",
   "failure_id": "MONGO-1",
-  "failure_event": "created",
-  "timestamp": 1557933657
+  "failure_event": "created"
 }

--- a/exporters/tests/data/webhook_pelorus_failure_resolved.json
+++ b/exporters/tests/data/webhook_pelorus_failure_resolved.json
@@ -1,6 +1,5 @@
 {
   "app": "mongo-todolist",
   "failure_id": "MONGO-1",
-  "failure_event": "resolved",
-  "timestamp": 1557933657
+  "failure_event": "resolved"
 }

--- a/exporters/tests/test_in_memory_metric.py
+++ b/exporters/tests/test_in_memory_metric.py
@@ -15,6 +15,7 @@
 #
 
 
+import time
 from unittest import mock
 
 import pytest
@@ -27,6 +28,8 @@ from webhook.store.in_memory_metric import (
     _pelorus_metric_to_dict,
     pelorus_metric_to_prometheus,
 )
+
+CURRENT_TIMESTAMP = int(time.time())
 
 metric_labels = list(_pelorus_metric_to_dict(CommitTimePelorusPayload).values())
 
@@ -61,7 +64,7 @@ class TestInMemoryMetric:
         [
             (
                 "todolist",
-                "1678269658",
+                str(CURRENT_TIMESTAMP),
                 "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
                 "mynamespace",
                 "5379bad65a3f83853a75aabec9e0e43c75fd18fc",

--- a/exporters/tests/test_pelorus_base_plugin.py
+++ b/exporters/tests/test_pelorus_base_plugin.py
@@ -299,8 +299,7 @@ async def test_handshake():
             "app": "mongo-todolist",
             "commit_hash": "5379bad65a3f83853a75aabec9e0e43c75fd18fc",
             "image_sha": "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
-            "namespace": "mongo-persistent",
-            "timestamp": "1557933657"
+            "namespace": "mongo-persistent"
         }""",
     ],
 )
@@ -316,7 +315,9 @@ async def test_proper_receive_metric(json_payload):
         "webhook.plugins.pelorus_handler_base.PelorusWebhookPlugin._receive",
         new_callable=AsyncMock,
     ) as mock_receive:
-        mock_receive.return_value = json.loads(json_payload)
+        payload_data = json.loads(json_payload)
+        payload_data["timestamp"] = int(time.time())
+        mock_receive.return_value = payload_data
         plugin = UserAgentWebhookPlugin(None, request=None)
         metric_data = await plugin.receive()
         assert issubclass(type(metric_data), PelorusMetric)

--- a/exporters/tests/test_webhook_models.py
+++ b/exporters/tests/test_webhook_models.py
@@ -14,6 +14,7 @@
 #    under the License.
 #
 
+import time
 from contextlib import nullcontext
 from secrets import choice
 from string import ascii_letters
@@ -32,9 +33,11 @@ from webhook.models.pelorus_webhook import (
 
 # TODO no tests for PelorusDeliveryHeaders
 
+CURRENT_TIMESTAMP = int(time.time())
+
 test_payload = {
     "app": "todolist",
-    "timestamp": "1678269658",
+    "timestamp": CURRENT_TIMESTAMP,
 }
 test_deploy = {
     **test_payload,
@@ -60,13 +63,13 @@ class FakePelorusPayload(BaseModel):
 
 
 @pytest.mark.parametrize(
-    "app,timestamp",
+    "app",
     [
-        (123456, 1678269658),
-        ("todolist", "1678269658"),
+        123456,
+        "todolist",
     ],
 )
-def test_pelorus_payload_success(app, timestamp):
+def test_pelorus_payload_success(app):
     """
     Test for the base PelorusPayload class. This class is inherited
     by every other payload classes and contains only two required
@@ -75,7 +78,7 @@ def test_pelorus_payload_success(app, timestamp):
     Checks the validations of the app and timestamp fields for various
     conditions.
     """
-    payload = PelorusPayload(app=app, timestamp=timestamp)
+    payload = PelorusPayload(app=app, timestamp=CURRENT_TIMESTAMP)
     assert payload.get_metric_model_name() == "PelorusPayload"
 
 

--- a/exporters/webhook/app.py
+++ b/exporters/webhook/app.py
@@ -117,12 +117,15 @@ async def prometheus_metric(received_metric: PelorusMetric):
 
     if received_metric_type == PelorusMetricSpec.COMMIT_TIME:
         in_memory_commit_metrics.add_metric(
-            metric.commit_hash, prometheus_metric, metric.timestamp
+            metric.commit_hash,
+            prometheus_metric,
+            metric.timestamp,
+            timestamp=metric.timestamp,
         )
     elif received_metric_type == PelorusMetricSpec.DEPLOY_TIME:
         metric_id = f"{metric.app}{metric.timestamp}"
         in_memory_deploy_timestamp_metric.add_metric(
-            metric_id, prometheus_metric, metric.timestamp
+            metric_id, prometheus_metric, metric.timestamp, timestamp=metric.timestamp
         )
     elif received_metric_type == PelorusMetricSpec.FAILURE:
         failure_type = metric.failure_event
@@ -130,11 +133,17 @@ async def prometheus_metric(received_metric: PelorusMetric):
 
         if failure_type == FailurePelorusPayload.FailureEvent.CREATED:
             in_memory_failure_creation_metric.add_metric(
-                metric_id, prometheus_metric, metric.timestamp
+                metric_id,
+                prometheus_metric,
+                metric.timestamp,
+                timestamp=metric.timestamp,
             )
         elif failure_type == FailurePelorusPayload.FailureEvent.RESOLVED:
             in_memory_failure_resolution_metric.add_metric(
-                metric_id, prometheus_metric, metric.timestamp
+                metric_id,
+                prometheus_metric,
+                metric.timestamp,
+                timestamp=metric.timestamp,
             )
         else:
             logging.error(f"Failure Metric {metric} can not be stored")

--- a/exporters/webhook/plugins/pelorus_handler.py
+++ b/exporters/webhook/plugins/pelorus_handler.py
@@ -260,7 +260,9 @@ class PelorusWebhookHandler(PelorusWebhookPlugin):
                 logging.error(self.payload_headers)
                 logging.error(json_payload_data)
                 logging.error(ex)
+                error_fields = ",".join(ex.errors()[0].get("loc"))
+                error_str = ex.errors()[0].get("msg")
                 raise HTTPException(
                     status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
-                    detail="Invalid payload.",
+                    detail=f"Invalid payload: {error_str}: {error_fields}",
                 )


### PR DESCRIPTION
Currently a valid event is the one that happened within 30min from the time of sending that event to our webhook exporter. This is the limitation of Prometheus that is not accepting events that are too old or are too far into the future.

Fixes also webhook exporter to contain timestamps for the events that occured.

Fixes: #934 
Fixes: #933