### PR TITLE
Ensure deploytime exporter accepts only valid timestamps

### DIFF
--- a/docs/GettingStarted/configuration/ExporterDeploytime.md
+++ b/docs/GettingStarted/configuration/ExporterDeploytime.md
@@ -2,6 +2,8 @@
 
 The job of the deploy time exporter is to capture the timestamp at which a deployment event happen in a production environment.
 
+Deploytime exporter only collects deployment events that are less than 30 minutes old. Older deployments won't be included unless they have been already collected.
+
 > **NOTE:** In order for proper collection, we require that all objects (Pods, Deployments, replicaSets, etc) associated with a particular application be labelled with the same [APP_LABEL](#app_label), which by default is `app.kubernetes.io/name=<app_name>`, where `<app_name>` is the name of the application being monitored.
 
 ## Example

--- a/docs/GettingStarted/configuration/ExporterWebhook.md
+++ b/docs/GettingStarted/configuration/ExporterWebhook.md
@@ -85,15 +85,19 @@ When sending an HTTP POST request to the webhook's configured URL endpoint, the 
 ##### deploytime
 For the Header X-Pelorus-Event: `deploytime`
 
+> **NOTE:** To align with the nature of Prometheus, it is required that the deploytime event being sent to the webhook exporter should not have occurred more than 30 minutes prior to the time of sending.
+
 | Key         | Type     | Description |
 |-------------|----------|---------------|
 | `app`       | `string` | Monitored application name |
 | `image_sha` | `string` | Image SHA used for deployment. Must be prefixed with the `sha256:` followed by 64 characters of small letters and numbers |
 | `namespace` | `string` | OpenShift namespace to which application was deployed |
-| `timestamp` | `int`    | EPOCH timestamp representing event occurrence. Allowed format: `10 digit int`|
+| `timestamp` | `int`    | EPOCH timestamp must be within the last 30 minutes. Allowed format: `10 digit int`|
 
 ##### committime
 For the Header X-Pelorus-Event: `committime`
+
+> **NOTE:** Committime event must be sent to the webhook exporter prior to it's related deploytime event.
 
 | Key           | Type     | Description |
 | ------------- |----------|-------------|
@@ -123,7 +127,7 @@ You can easily send a POST request using [Curl](https://curl.se) directly from t
 * Our application:
     * is named **`mongo-todolist`** in OpenShift.
     * is deployed to the **`mongo-persistent`** namespace.
-    * deployment happened at (EPOCH): **`1678106205`**
+    * deployment happened 10 minutes ago (EPOCH): **`$ date -d '10 min ago' +%s`**
 
     * the container image used for the deployment has SHA **`af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d`**
 

--- a/exporters/tests/data/webhook_pelorus_committime.json
+++ b/exporters/tests/data/webhook_pelorus_committime.json
@@ -3,5 +3,5 @@
   "commit_hash": "5379bad65a3f83853a75aabec9e0e43c75fd18fc",
   "image_sha": "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
   "namespace": "mongo-persistent",
-  "timestamp": 1557933657
+  "timestamp": 1682936938
 }

--- a/exporters/tests/data/webhook_pelorus_deploytime.json
+++ b/exporters/tests/data/webhook_pelorus_deploytime.json
@@ -2,5 +2,5 @@
   "app": "mongo-todolist",
   "image_sha": "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
   "namespace": "mongo-persistent",
-  "timestamp": 1557933657
+  "timestamp": 1683022138
 }

--- a/exporters/tests/data/webhook_pelorus_failure_created.json
+++ b/exporters/tests/data/webhook_pelorus_failure_created.json
@@ -2,5 +2,5 @@
   "app": "mongo-todolist",
   "failure_id": "MONGO-1",
   "failure_event": "created",
-  "timestamp": 1557933657
+  "timestamp": 1683022198
 }

--- a/exporters/tests/data/webhook_pelorus_failure_resolved.json
+++ b/exporters/tests/data/webhook_pelorus_failure_resolved.json
@@ -2,5 +2,5 @@
   "app": "mongo-todolist",
   "failure_id": "MONGO-1",
   "failure_event": "resolved",
-  "timestamp": 1557933657
+  "timestamp": 1683023338
 }

--- a/exporters/tests/test_in_memory_metric.py
+++ b/exporters/tests/test_in_memory_metric.py
@@ -15,6 +15,7 @@
 #
 
 
+import time
 from unittest import mock
 
 import pytest
@@ -27,6 +28,8 @@ from webhook.store.in_memory_metric import (
     _pelorus_metric_to_dict,
     pelorus_metric_to_prometheus,
 )
+
+CURRENT_TIMESTAMP = int(time.time())
 
 metric_labels = list(_pelorus_metric_to_dict(CommitTimePelorusPayload).values())
 
@@ -61,7 +64,7 @@ class TestInMemoryMetric:
         [
             (
                 "todolist",
-                "1678269658",
+                str(CURRENT_TIMESTAMP),
                 "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
                 "mynamespace",
                 "5379bad65a3f83853a75aabec9e0e43c75fd18fc",

--- a/exporters/tests/test_pelorus_base_plugin.py
+++ b/exporters/tests/test_pelorus_base_plugin.py
@@ -299,8 +299,7 @@ async def test_handshake():
             "app": "mongo-todolist",
             "commit_hash": "5379bad65a3f83853a75aabec9e0e43c75fd18fc",
             "image_sha": "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
-            "namespace": "mongo-persistent",
-            "timestamp": "1557933657"
+            "namespace": "mongo-persistent"
         }""",
     ],
 )
@@ -316,7 +315,9 @@ async def test_proper_receive_metric(json_payload):
         "webhook.plugins.pelorus_handler_base.PelorusWebhookPlugin._receive",
         new_callable=AsyncMock,
     ) as mock_receive:
-        mock_receive.return_value = json.loads(json_payload)
+        payload_data = json.loads(json_payload)
+        payload_data["timestamp"] = int(time.time())
+        mock_receive.return_value = payload_data
         plugin = UserAgentWebhookPlugin(None, request=None)
         metric_data = await plugin.receive()
         assert issubclass(type(metric_data), PelorusMetric)

--- a/exporters/tests/test_webhook_models.py
+++ b/exporters/tests/test_webhook_models.py
@@ -14,6 +14,7 @@
 #    under the License.
 #
 
+import time
 from contextlib import nullcontext
 from secrets import choice
 from string import ascii_letters
@@ -32,9 +33,11 @@ from webhook.models.pelorus_webhook import (
 
 # TODO no tests for PelorusDeliveryHeaders
 
+CURRENT_TIMESTAMP = int(time.time())
+
 test_payload = {
     "app": "todolist",
-    "timestamp": "1678269658",
+    "timestamp": CURRENT_TIMESTAMP,
 }
 test_deploy = {
     **test_payload,
@@ -60,13 +63,13 @@ class FakePelorusPayload(BaseModel):
 
 
 @pytest.mark.parametrize(
-    "app,timestamp",
+    "app",
     [
-        (123456, 1678269658),
-        ("todolist", "1678269658"),
+        123456,
+        "todolist",
     ],
 )
-def test_pelorus_payload_success(app, timestamp):
+def test_pelorus_payload_success(app):
     """
     Test for the base PelorusPayload class. This class is inherited
     by every other payload classes and contains only two required
@@ -75,7 +78,7 @@ def test_pelorus_payload_success(app, timestamp):
     Checks the validations of the app and timestamp fields for various
     conditions.
     """
-    payload = PelorusPayload(app=app, timestamp=timestamp)
+    payload = PelorusPayload(app=app, timestamp=CURRENT_TIMESTAMP)
     assert payload.get_metric_model_name() == "PelorusPayload"
 
 

--- a/exporters/webhook/README.md
+++ b/exporters/webhook/README.md
@@ -16,24 +16,53 @@ $ python exporters/webhook/app.py
 To send some data you can use simple curl:
 ```shell
 $ cd exporters/tests/data
+
+# Set times when the events actually happens
+
+# Commit happened 1 day ago:
+$ COMMIT_EVENT_TIMESTAMP=$(date -d '1 day ago' +%s)
+
+# Deploy event must have happened maximum 30min ago:
+$ DEPLOY_EVENT_TIMESTAMP=$(date -d '20 min ago' +%s)
+
+# Failure happened just after deployment, let's say 19min ago
+$ FAILURE_CREATE_TIMESTAMP=$(date -d '19 min ago' +%s)
+
+# Failure was resolved now
+$ FAILURE_RESOLVED_TIMESTAMP=$(date +%s)
+
+# Copy test files to the temp directory, so we don't modify the ones from the git repository
+$ TMP_DIR=$(mkfile -d)
+$ cp webhook_pelorus_*.json "$TMP_DIR"
+$ pushd "$TMP_DIR"
+
+# Modify the temporary files with the proper timestamps
+$ sed -i "s/\"timestamp\":.*/\"timestamp\": $COMMIT_EVENT_TIMESTAMP/" ./webhook_pelorus_committime.json
+$ sed -i "s/\"timestamp\":.*/\"timestamp\": $DEPLOY_EVENT_TIMESTAMP/" ./webhook_pelorus_deploytime.json
+$ sed -i "s/\"timestamp\":.*/\"timestamp\": $FAILURE_CREATE_TIMESTAMP/" ./webhook_pelorus_failure_created.json
+$ sed -i "s/\"timestamp\":.*/\"timestamp\": $FAILURE_RESOLVED_TIMESTAMP/" ./webhook_pelorus_failure_resolved.json
+
+
+# Send the events to the webhook endpoint
+
 $ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_committime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: committime"
 $ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_deploytime.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: deploytime"
 $ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_failure_created.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: failure"
 $ curl -X POST http://localhost:8080/pelorus/webhook -d @./webhook_pelorus_failure_resolved.json -H "Content-Type: application/json" -H "User-Agent: Pelorus-Webhook/test" -H "X-Pelorus-Event: failure"
 ```
 
-Navigate to the endpoint [http://localhost:8080/metrics](http://localhost:8080/metrics), you should see all the metrics:
+Navigate to the endpoint [http://localhost:8080/metrics](http://localhost:8080/metrics), you should see all the metrics, similar to:
 ```
 # HELP commit_timestamp Commit timestamp
 # TYPE commit_timestamp gauge
-commit_timestamp{app="mongo-todolist",commit_hash="5379bad65a3f83853a75aabec9e0e43c75fd18fc",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.557933657e+09
+commit_timestamp{app="mongo-todolist",commit_hash="5379bad65a3f83853a75aabec9e0e43c75fd18fc",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.682936938e+09
 # HELP deploy_timestamp Deployment timestamp
 # TYPE deploy_timestamp gauge
-deploy_timestamp{app="mongo-todolist",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.557933657e+09
+deploy_timestamp{app="mongo-todolist",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.683022138e+09 1683022138000
 # HELP failure_creation_timestamp Failure Creation Timestamp
 # TYPE failure_creation_timestamp gauge
-failure_creation_timestamp{app="mongo-todolist",failure_id="MONGO-1"} 1.557933657e+09
+failure_creation_timestamp{app="mongo-todolist",failure_id="MONGO-1"} 1.683022198e+09
 # HELP failure_resolution_timestamp Failure Resolution Timestamp
 # TYPE failure_resolution_timestamp gauge
-failure_resolution_timestamp{app="mongo-todolist",failure_id="MONGO-1"} 1.557933657e+09
+failure_resolution_timestamp{app="mongo-todolist",failure_id="MONGO-1"} 1.683023338e+09
 ```

--- a/exporters/webhook/app.py
+++ b/exporters/webhook/app.py
@@ -122,7 +122,7 @@ async def prometheus_metric(received_metric: PelorusMetric):
     elif received_metric_type == PelorusMetricSpec.DEPLOY_TIME:
         metric_id = f"{metric.app}{metric.timestamp}"
         in_memory_deploy_timestamp_metric.add_metric(
-            metric_id, prometheus_metric, metric.timestamp
+            metric_id, prometheus_metric, metric.timestamp, timestamp=metric.timestamp
         )
     elif received_metric_type == PelorusMetricSpec.FAILURE:
         failure_type = metric.failure_event

--- a/exporters/webhook/plugins/pelorus_handler.py
+++ b/exporters/webhook/plugins/pelorus_handler.py
@@ -260,7 +260,9 @@ class PelorusWebhookHandler(PelorusWebhookPlugin):
                 logging.error(self.payload_headers)
                 logging.error(json_payload_data)
                 logging.error(ex)
+                error_fields = ",".join(ex.errors()[0].get("loc"))
+                error_str = ex.errors()[0].get("msg")
                 raise HTTPException(
                     status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
-                    detail="Invalid payload.",
+                    detail=f"Invalid payload: {error_str}: {error_fields}",
                 )


### PR DESCRIPTION
Make deploytime exporter consistent between webhook and deploy type exporter.

## Problem

Current exposed [metric](https://github.com/dora-metrics/pelorus/blob/616ff8f4ebbd807038e93de15e5f8c14da7c4b2e/exporters/webhook/app.py#L124-L126) format of the webhook's deploytime is different from the original deploytime exporter [metric](https://github.com/dora-metrics/pelorus/blob/616ff8f4ebbd807038e93de15e5f8c14da7c4b2e/exporters/deploytime/app.py#L55-L59).

The difference is visible below and shows that the webhook exporter implementation does not add timestamp() to the metric. 

There are few reasons why *not* to include the timestamp within the metric as discussed under https://github.com/dora-metrics/pelorus/discussions/956, however with current queries and Prometheus limitations we are required to use it, so we record deployments accurately.

This is especially visible when using webhook exporter that allows to manipulate the timestamps. On top of that the differences in recording metrics caused additional problems in the Grafana dashboards presenting incorrect data, because original deploytime was considered an event that have happened at particular point of time and webhook caused this to be a series of metrics with different timestamps and particular value. In short webhook converted an event to a time series.

```
# Webhook exporter:
deploy_timestamp{app="mongo-todolist",image_sha="sha256:bf4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.682585478e+09

# The original deploytime exporter:
deploy_timestamp{app="mongo-todolist",image_sha="sha256:bf4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.682585478e+09 1682585478000
```

## Describe the behavior changes introduced in this PR

In this PR the webhook and deploy time exporter behaves exactly the same way making webhook consistent rather than changing the current deploy time and the queries associated with the current metrics.

The change does modify the webhook commit time and failure time code, but the time verification applies only to the deploy time.

The accepted samples for the deploy time exporter and deploy events received by webhook must be within 30min prior to sending that payload. This is due to Prometheus limitation. Please consider discussing https://github.com/dora-metrics/pelorus/discussions/956 as another options which would remove such limitation.