### PR TITLE
fix: Choose PR template from UI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please go the the `Preview` tab and select the appropriate template for your PR:
+
+* [General PR](?expand=1&template=general_template.md)
+* [Release PR](?expand=1&template=release_template.md)


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

No.

## Description

After #940, a new PR template was added, but GitHub does not show the templates options when user creates an PR through the UI.

## Testing Instructions

After merging, the user can choose a PR template through `.github/pull_request_template.md`. 
