### PR TITLE
fix: Custom action pydantic attribute name

### DIFF
--- a/.github/workflow_templates/comment-pr/main.py
+++ b/.github/workflow_templates/comment-pr/main.py
@@ -6,7 +6,7 @@ from pydantic import BaseSettings, SecretStr
 
 class Settings(BaseSettings):
     input_token: SecretStr
-    pr_number: int
+    input_pr_number: int
     input_message: str
 
 
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         logging.info(f"Loaded settings: {settings.json()}")
         github_api = Github(settings.input_token.get_secret_value())
         repo = github_api.get_repo("dora-metrics/pelorus")
-        pull_request = repo.get_issue(number=settings.pr_number)
+        pull_request = repo.get_issue(number=settings.input_pr_number)
         pull_request.create_comment(settings.input_message)
     except Exception as error:
         logging.error(f"An error ocurred: {error}")


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

related to #881

## Description

Fix pydantic attribute name (so it can read what GitHub actions send to it).

## Testing Instructions

Check following PR.
