### PR TITLE
fix: Checkout code from trigger branch

### DIFF
--- a/.github/workflows/trigger-test-images.yml
+++ b/.github/workflows/trigger-test-images.yml
@@ -1,4 +1,4 @@
-name: Trigger test images
+name: Trigger test images (test)
 
 on:
   pull_request:
@@ -29,7 +29,15 @@ jobs:
               '"pr_number":"${{ github.event.number }}",' \
               '"commit_hash":"${{ needs.get-short-sha.outputs.sha }}"}' > trigger-information.json
 
-      - uses: actions/upload-artifact@v3
+      # - uses: actions/upload-artifact@v3
+      #   with:
+      #     name: trigger-information
+      #     path: ./trigger-information.json
+
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
-          name: trigger-information
-          path: ./trigger-information.json
+          ref: ${{ github.ref }}
+
+      - name: DEBUG
+        run: ls -1


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

related to #881

## Description

Operator test image are being built on top of master branch, they should be built on top of trigger branch. this PR fixes this.

## Testing Instructions

Check following PRs.
