### PR TITLE
Rework of deploytime codebase

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.4
+version: 2.0.10-rc.5

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.4
-digest: sha256:04fb28d4a4f31ae5cd881d22cbe0625e628cf80c70740ea89b8f1b8e611a87c2
-generated: "2023-05-10T14:37:49.160006936-03:00"
+  version: 2.0.10-rc.5
+digest: sha256:81bd39a2f18c82e32cf006453b20b0e7bb16b343b10e48a196d480463973ef68
+generated: "2023-05-15T16:12:35.760966639+02:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.4
+version: 2.0.10-rc.5
 
 dependencies:
   - name: exporters
-    version: 2.0.10-rc.4
+    version: 2.0.10-rc.5
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.4
+version: 2.0.10-rc.5

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.4" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.5" }}
             {{- end }}
 
             {{- if .extraEnv }}

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.4" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.5" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -255,7 +255,7 @@ If not defined specifically, exporters are using pre-built container images with
 
 Each Pelorus GitHub pull request that is [merged](https://github.com/dora-metrics/pelorus/pulls?q=is%3Apr+is%3Amerged) results in a new set of images that are tagged with the GitHub commit hash, for example `d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31` for the following [Pull Request](https://github.com/dora-metrics/pelorus/commit/d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31). The newest merged commit results in additional image tag `latest`.
 
-Each new Pelorus [release](https://github.com/dora-metrics/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.9`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
+Each new Pelorus [release](https://github.com/dora-metrics/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.10-rc.5`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
 
 During Pelorus Helm deployment or update time user have option to specify the image tag for each exporter instance individually. Example below shows two different tags for the commit time exporter and two tags for the failure exporter.
 
@@ -295,7 +295,7 @@ exporters:
 
   - app_name: jira-failure-exporter
     exporter_type: failure
-    image_tag: v2.0.9 # Specific release
+    image_tag: v2.0.10-rc.5 # Specific release
     env_from_secrets:
     - jira-credentials
     env_from_configmaps:

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -1,11 +1,9 @@
 import logging
-import re
 import time
-from typing import Iterable, Optional
+from typing import Iterable
 
 from attrs import field, frozen
-from openshift.dynamic import DynamicClient, ResourceInstance
-from openshift.dynamic.exceptions import ResourceNotFoundError
+from openshift.dynamic import DynamicClient
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY, GaugeMetricFamily
 
@@ -14,8 +12,13 @@ from deploytime import DeployTimeMetric
 from pelorus.config import load_and_log, no_env_vars
 from pelorus.config.converters import comma_separated
 from pelorus.timeutil import METRIC_TIMESTAMP_THRESHOLD_MINUTES, is_out_of_date
-
-supported_replica_objects = {"ReplicaSet", "ReplicationController"}
+from provider_common.openshift import (
+    filter_pods_by_replica_uid,
+    get_and_log_namespaces,
+    get_images_from_pod,
+    get_owner_object_from_child,
+    get_running_pods,
+)
 
 
 @frozen
@@ -30,7 +33,6 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
 
     def collect(self) -> Iterable[GaugeMetricFamily]:
         logging.info("collect: start")
-
         metrics = self.generate_metrics()
 
         deploy_timestamp_metric = GaugeMetricFamily(
@@ -43,7 +45,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
 
         for m in metrics:
             if not is_out_of_date(str(m.deploy_time_timestamp)):
-                logging.info(
+                logging.debug(
                     "Collected deploy_timestamp{namespace=%s, app=%s, image=%s} %s (%s)",
                     m.namespace,
                     m.name,
@@ -67,168 +69,45 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
                     m.deploy_time_timestamp,
                 )
         if number_of_dropped:
-            logging.debug(
+            logging.info(
                 "Number of deployments that are older then %smin and won't be collected: %s",
                 METRIC_TIMESTAMP_THRESHOLD_MINUTES,
                 number_of_dropped,
             )
         yield deploy_timestamp_metric
 
-    def get_and_log_namespaces(self) -> set[str]:
-        """
-        Get the set of namespaces to watch, and log what they are.
-        They will be either:
-        1. The namespaces explicitly specified
-        2. The namespaces matched by PROD_LABEL
-        3. If neither namespaces nor the PROD_LABEL is given, then implicitly matches all namespaces.
-        """
-        if self.namespaces:
-            logging.info("Watching namespaces %s", self.namespaces)
-            return self.namespaces
-
-        if self.prod_label:
-            logging.info(
-                "No namespaces specified, watching all namespaces with given PROD_LABEL (%s)",
-                self.prod_label,
-            )
-            query_args = dict(label_selector=self.prod_label)
-        else:
-            logging.info(
-                "No namespaces specified and no PROD_LABEL given, watching all namespaces."
-            )
-            query_args = dict()
-
-        all_namespaces = self.client.resources.get(api_version="v1", kind="Namespace")
-        namespaces = {
-            namespace.metadata.name
-            for namespace in all_namespaces.get(**query_args).items
-        }
-        logging.info("Watching namespaces %s", namespaces)
-        if not namespaces:
-            logging.warning(
-                "No NAMESPACES given and PROD_LABEL did not return any matching namespaces."
-            )
-        return namespaces
-
     def generate_metrics(self) -> Iterable[DeployTimeMetric]:
-        namespaces = self.get_and_log_namespaces()
+        namespaces = get_and_log_namespaces(
+            self.client, self.namespaces, self.prod_label
+        )
+
         if not namespaces:
             return []
 
-        app_label = self.app_label
-        visited_replicas = set()
-
-        def already_seen(full_path: str) -> bool:
-            return full_path in visited_replicas
-
-        def mark_as_seen(full_path: str):
-            visited_replicas.add(full_path)
-
         logging.info("generate_metrics: start")
 
-        # get all running Pods with the app label
-        v1_pods = self.client.resources.get(api_version="v1", kind="Pod")
-        pods = v1_pods.get(
-            label_selector=app_label, field_selector="status.phase=Running"
-        ).items
+        pods = get_running_pods(self.client, namespaces, self.app_label)
 
-        replicas_dict = (
-            self.get_replicas("v1", "ReplicationController")
-            | self.get_replicas("apps/v1", "ReplicaSet")
-            | self.get_replicas("extensions/v1beta1", "ReplicaSet")
-        )
+        # Build dictionary with controllers and retrieved pods
+        replica_pods_dict = filter_pods_by_replica_uid(pods)
 
-        for pod in pods:
-            namespace = pod.metadata.namespace
-            owner_refs = pod.metadata.ownerReferences
-            if namespace not in namespaces or not owner_refs:
-                continue
+        for uid, pod in replica_pods_dict.items():
+            replicas = get_owner_object_from_child(self.client, uid, pod)
 
-            logging.debug(
-                "Getting Replicas for pod: %s in namespace: %s",
-                pod.metadata.name,
-                pod.metadata.namespace,
-            )
+            # Since a commit will be built into a particular image and there could be multiple
+            # containers (images) per pod, we will push one metric per image/container in the
+            # pod template
+            images = get_images_from_pod(pod)
 
-            # Get deploytime from the owning controller of the pod.
-            # We track all already-visited controllers to not duplicate metrics per-pod.
-            for ref in owner_refs:
-                full_path = f"{namespace}/{ref.name}"
-
-                if ref.kind not in supported_replica_objects or already_seen(full_path):
-                    continue
-
-                logging.debug(
-                    "Getting replica: %s, kind: %s, namespace: %s",
-                    ref.name,
-                    ref.kind,
-                    namespace,
+            for sha in images.keys():
+                metric = DeployTimeMetric(
+                    name=pod.metadata.labels[self.app_label],
+                    namespace=pod.metadata.namespace,
+                    labels=pod.metadata.labels,
+                    deploy_time=replicas.get(uid).metadata.creationTimestamp,
+                    image_sha=sha,
                 )
-
-                if not (rc := replicas_dict.get(full_path)):
-                    continue
-
-                mark_as_seen(full_path)
-                container_shas = (
-                    image_sha(container.image) for container in pod.spec.containers
-                )
-                container_status_shas = (
-                    image_sha(status.imageID) for status in pod.status.containerStatuses
-                )
-                images = {sha for sha in container_shas if sha} | {
-                    sha for sha in container_status_shas if sha
-                }
-
-                # Since a commit will be built into a particular image and there could be multiple
-                # containers (images) per pod, we will push one metric per image/container in the
-                # pod template
-                for sha in images:
-                    metric = DeployTimeMetric(
-                        name=rc.metadata.labels[app_label],
-                        namespace=namespace,
-                        labels=rc.metadata.labels,
-                        deploy_time=rc.metadata.creationTimestamp,
-                        image_sha=sha,
-                    )
-                    yield metric
-
-    def get_replicas(
-        self, apiVersion: str, objectName: str
-    ) -> dict[str, ResourceInstance]:
-        """Process Replicas for given Api Version and Object type (ReplicaSet or ReplicationController)"""
-        try:
-            apiResource = self.client.resources.get(
-                api_version=apiVersion, kind=objectName
-            )
-            replicationobjects = apiResource.get(label_selector=self.app_label)
-            return {
-                f"{replica.metadata.namespace}/{replica.metadata.name}": replica
-                for replica in replicationobjects.items
-            }
-        except ResourceNotFoundError:
-            logging.debug(
-                "API Object not found for version: %s object: %s",
-                apiVersion,
-                objectName,
-            )
-        return {}
-
-
-def image_sha(image_url_or_id: str) -> Optional[str]:
-    """
-    Gets the hash of the image, extracted from the image URL or image ID.
-
-    Specifically, everything after the first `sha256:` seen.
-    """
-    sha_regex = re.compile(r"sha256:.*")
-    if match := sha_regex.search(image_url_or_id):
-        return match.group()
-    else:
-        # This may be noisy if there are a lot of pods where the container
-        # spec doesn't have a SHA but the status does.
-        # But since it's only in debug logs, it doesn't matter.
-        logging.debug("Skipping unresolved image reference: %s", image_url_or_id)
-        return None
+                yield metric
 
 
 if __name__ == "__main__":

--- a/exporters/provider_common/openshift.py
+++ b/exporters/provider_common/openshift.py
@@ -1,10 +1,59 @@
+import logging
+import re
+import time
 from datetime import datetime
-from typing import Union
+from typing import Dict, List, Optional, Set, Tuple, Union
+
+from openshift.dynamic import DynamicClient, ResourceInstance
+from openshift.dynamic.exceptions import ResourceNotFoundError
+from openshift.dynamic.resource import ResourceField
 
 from pelorus.timeutil import parse_assuming_utc
 
 # https://docs.openshift.com/container-platform/4.10/rest_api/objects/index.html#io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
 _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+SUPPORTED_REPLICA_OBJECTS = ["ReplicaSet", "ReplicationController"]
+
+# Cache threshold in seconds, used by every cached_parents_dict entry
+CACHE_THRESHOLD_1_DAY = 60 * 60 * 24
+cached_parents_dict: dict[str, Tuple[ResourceInstance, float]] = {}
+
+
+def _add_object_to_cache(uid: str, k8s_obj: ResourceInstance) -> None:
+    """
+    Create in-memory cache for the K8S objects, so we don't have
+    to query them each time.
+
+    We have also 'timeout' for each cache entry, which means
+    we won't grow the cache infinitely.
+    """
+    if uid not in cached_parents_dict:
+        cached_parents_dict[uid] = (k8s_obj, time.time())
+
+
+def _get_object_from_cache(uid: str) -> ResourceInstance:
+    """
+    Gets the object from the cache by it's uid.
+    """
+    k8s_obj, _ = cached_parents_dict.get(uid) or (None, None)
+    return k8s_obj
+
+
+def _remove_expired_objects() -> None:
+    """
+    Cleanup function to remove expired objects from the cache.
+    """
+    current_time = time.time()
+
+    expired_keys = [
+        uid
+        for uid, (_, insertion_time) in cached_parents_dict.items()
+        if current_time - insertion_time > CACHE_THRESHOLD_1_DAY
+    ]
+    for uid in expired_keys:
+        if uid in cached_parents_dict:
+            del cached_parents_dict[uid]
 
 
 def parse_datetime(dt_str: str) -> datetime:
@@ -19,3 +68,238 @@ def convert_datetime(dt: Union[str, datetime]) -> datetime:
         return dt
     else:
         return parse_datetime(dt)
+
+
+def get_running_pods(
+    client: DynamicClient,
+    namespaces: Optional[Set[str]] = None,
+    app_label: Optional[str] = None,
+    with_owner_only: bool = True,
+) -> List[ResourceField]:
+    """
+    Retrieves running pods in the OpenShift cluster that have a parent owner,
+    which can be either a ReplicaSet or ReplicationController.
+
+    Optionally the function retrieves the pods by the provided namespaces.
+    If the `app_label` parameter is provided, it only returns pods that have a label
+    that matches the specified label.
+
+    Args:
+        client (DynamicClient): An OpenShift client object.
+        namespaces (Optional[Set[str]]): Namespaces for which to discover pods. If not provided,
+                                         the function retrieves pods in all namespaces.
+        app_label (Optional[str]): A label that a pod must have to be considered production.
+                                   By default, no label is required.
+        with_owner_only (bool): A flag that determines whether to return only pods with ownerReferences or all pods.
+                                By default, the function only returns pods with ownerReferences.
+
+    Returns:
+        List[ResourceField]: A list of ResourceField objects representing the running pods in the
+                             OpenShift cluster that meet the criteria.
+    """
+
+    v1_services = client.resources.get(api_version="v1", kind="Pod")
+
+    pods = []
+
+    for ns in namespaces or {""}:
+        pods += v1_services.get(
+            label_selector=app_label,
+            field_selector="status.phase=Running",
+            namespace=ns,
+        ).items
+
+    if with_owner_only:
+        return [
+            ocp_object
+            for ocp_object in pods
+            if ocp_object.metadata.ownerReferences
+            and any(
+                owner_ref.kind in SUPPORTED_REPLICA_OBJECTS
+                for owner_ref in ocp_object.metadata.ownerReferences
+            )
+        ]
+
+    return pods
+
+
+def get_owner_object_from_child(
+    client: DynamicClient, uid: str, child_object: ResourceField
+) -> Dict[str, ResourceInstance]:
+    """
+    Retrieves the OpenShift Parent object by its UID, using information about the API version and resource type
+    from the given Child object.
+
+    Args:
+        client (DynamicClient): An OpenShift client object.
+        uid (str): The UID of the Parent object.
+        child_object (ResourceField): The Child object that contains the reference to the Parent object.
+
+    Returns:
+        Dict[str, ResourceField]: A dictionary with the UID of the Parent object as the key
+                                  and the Parent object itself as the value.
+                                  An empty dictionary is returned if the Parent object is not found
+                                  or if there is an error during the retrieval.
+    """
+
+    owner_ref = next(
+        (owner for owner in child_object.metadata.ownerReferences if owner.uid == uid),
+        None,
+    )
+
+    if owner_ref:
+        _remove_expired_objects()
+        replica = _get_object_from_cache(owner_ref.uid)
+        if replica:
+            return {owner_ref.uid: replica}
+
+        logging.debug(
+            "Getting replica: %s, kind: %s, api_version: %s",
+            owner_ref.uid,
+            owner_ref.kind,
+            owner_ref.apiVersion,
+        )
+
+        try:
+            api_resource = client.resources.get(
+                api_version=owner_ref.apiVersion, kind=owner_ref.kind
+            )
+
+            # We don't need to limit for a given namespace, because Replica objects may live in other
+            # then Pod namespace, so we may get multiple replica objects for a given name.
+            # The field_selector does not work on the UID, that's why we need to match separately
+            replica_list = api_resource.get(
+                field_selector=f"metadata.name={owner_ref.name}"
+            )
+
+            for replica in replica_list.items:
+                if replica.metadata.uid == owner_ref.uid:
+                    _add_object_to_cache(owner_ref.uid, replica)
+                    return {owner_ref.uid: replica}
+        except ResourceNotFoundError:
+            logging.debug(
+                "API Object not found for version: %s object: %s",
+                owner_ref.apiVersion,
+                owner_ref.uid,
+            )
+    return {}
+
+
+def filter_pods_by_replica_uid(
+    pods_list: List[ResourceField],
+) -> Dict[str, ResourceField]:
+    """
+    Filters out the given list of Pod objects to create a dictionary with ReplicaSet or
+    ReplicationController UIDs as keys.
+
+    In OpenShift, one Pod may have multiple ownerReferences. This function filters the list of
+    Pod objects to identify unique ReplicaSet or ReplicationController objects based on their UID,
+    which is stored in the ownerReferences attribute of the Pod object.
+
+    Since Pods within a ReplicaSet are homogeneous and identical replicas,
+    we can filter out unique ReplicaSet objects even if multiple Pods are deployed.
+
+    Args:
+        pods_list (List[ResourceField]): A list of Pod objects.
+
+    Returns:
+        Dict[str, ResourceField]
+                A dictionary with ReplicaSet or ReplicationController UIDs as keys and Pod objects as values.
+    """
+    return {
+        owner_reference.uid: pod
+        for pod in pods_list
+        for owner_reference in pod.metadata.ownerReferences or []
+        if hasattr(owner_reference, "uid")
+    }
+
+
+def get_and_log_namespaces(
+    client: DynamicClient, namespaces: set[str], prod_label: str
+) -> set[str]:
+    """
+    Get the set of namespaces to watch, and log what they are.
+    They will be either:
+    1. The namespaces explicitly specified
+    2. The namespaces matched by PROD_LABEL
+    3. If neither namespaces nor the PROD_LABEL is given, then implicitly matches all namespaces.
+    """
+    if namespaces:
+        logging.info("Watching namespaces %s", namespaces)
+        return namespaces
+
+    if prod_label:
+        logging.info(
+            "No namespaces specified, watching all namespaces with given PROD_LABEL (%s)",
+            prod_label,
+        )
+        query_args = dict(label_selector=prod_label)
+    else:
+        logging.info(
+            "No namespaces specified and no PROD_LABEL given, watching all namespaces."
+        )
+        query_args = dict()
+
+    all_namespaces = client.resources.get(api_version="v1", kind="Namespace")
+    namespaces = {ns.metadata.name for ns in all_namespaces.get(**query_args).items}
+    logging.info("Watching namespaces %s", namespaces)
+    if not namespaces:
+        logging.warning(
+            "No NAMESPACES given and PROD_LABEL did not return any matching namespaces."
+        )
+    return namespaces
+
+
+def _parse_container_image_uri(
+    image_uri: str,
+) -> Union[Tuple[str, str, str], Tuple[None, None, None]]:
+    """
+    Parses the container image URI and extracts image registry, image name and image SHA256 value.
+
+    Args:
+        image_uri[str]: Container image URI.
+            Expected is an URI with registry URI and SHA256 value.
+
+    Returns:
+        Tuple[str, str, str]
+            Parsed container URI into Tuple of registry URI, image name and SHA256 value.
+            If any of the expected values is not found it then returns (None, None, None).
+    """
+    pattern = re.compile(
+        r"^(?P<registry>[^/]+/[^/]+/)?(?P<image_name>[^@]+)@(?P<sha256_value>sha256:[a-fA-F0-9]{64})$"
+    )
+    match = pattern.match(image_uri)
+    if match:
+        registry = match.group("registry")
+        image_name = match.group("image_name")
+        sha256_value = match.group("sha256_value")
+        if registry and image_name and sha256_value:
+            return registry, image_name, sha256_value
+    else:
+        # This may be noisy if there are a lot of pods where the container
+        # spec doesn't have a SHA but the status does.
+        # But since it's only in debug logs, it doesn't matter.
+        logging.debug("Skipping unresolved image reference: %s", image_uri)
+    return None, None, None
+
+
+def get_images_from_pod(pod: ResourceField) -> Dict[str, str]:
+    """
+    Get the image with it's sha256 from the pod (imageID). The parent object such as
+    ReplicaSet may contain only image reference by label and not the unique
+    sha256, which isn't ideal, so we need to aggregate the images from the
+    running pods and corresponding parent objects.
+    """
+
+    # Once we move fully to python 3.10+ we can replace with:
+    # if (containers := replica.spec.template.spec.containers) is not None and containers:
+    image_shas = {}
+    if pod and pod.status and pod.status.containerStatuses:
+        for container_status in pod.status.containerStatuses:
+            image_id = container_status.imageID
+            registry, image_name, sha256_value = _parse_container_image_uri(image_id)
+            if sha256_value and registry and image_name:
+                image_shas[
+                    sha256_value
+                ] = f"docker://{registry}{image_name}{sha256_value}"
+    return image_shas

--- a/exporters/tests/openshift_mocks.py
+++ b/exporters/tests/openshift_mocks.py
@@ -7,11 +7,14 @@ import attr
 class OwnerRef:
     kind: str
     name: str
+    uid: str
+    apiVersion: str
 
 
 @attr.define
 class Metadata:
     name: str
+    uid: Optional[str] = None
     namespace: Optional[str] = None
     ownerReferences: list[OwnerRef] = attr.Factory(list)
     labels: dict[str, str] = attr.Factory(dict)
@@ -49,10 +52,16 @@ class Pod:
 class Replicator:
     "Represents a ReplicationController or a ReplicaSet"
     kind: str
+    apiVersion: str
     metadata: Metadata
 
     def ref(self) -> OwnerRef:
-        return OwnerRef(kind=self.kind, name=self.metadata.name)
+        return OwnerRef(
+            kind=self.kind,
+            name=self.metadata.name,
+            uid=self.metadata.uid,
+            apiVersion=self.apiVersion,
+        )
 
 
 Item = TypeVar("Item")

--- a/exporters/tests/test_commons_openshift.py
+++ b/exporters/tests/test_commons_openshift.py
@@ -1,0 +1,52 @@
+import pytest
+
+from provider_common.openshift import _parse_container_image_uri
+
+
+@pytest.mark.parametrize(
+    "registry, image, sha",
+    [
+        (
+            "quay.io/centos7/",
+            "httpd-24-centos7",
+            "@sha256:ac78ddd61b5d11f8d1f9e43bec63cce5f962d485f8cdd8e55f9ea8486878ba7b",
+        ),
+        (
+            "image-registry.openshift-image-registry.svc:5000/openshift/",
+            "httpd",
+            "@sha256:95c922088ef9dec82db2ddd81b439c7f1df8d630af471f72c0e8d2606077ea7b",
+        ),
+    ],
+)
+def test_image_sha(registry: str, image: str, sha: str) -> None:
+    assert _parse_container_image_uri(f"{registry}{image}{sha}") == (
+        registry,
+        image,
+        sha.replace("@", ""),
+    )
+
+
+@pytest.mark.parametrize(
+    "registry, image, sha",
+    [
+        (
+            None,
+            "httpd-24-centos7",
+            "@sha256:ac78ddd61b5d11f8d1f9e43bec63cce5f962d485f8cdd8e55f9ea8486878ba7b",
+        ),
+        (
+            None,
+            None,
+            "@sha256:ac78ddd61b5d11f8d1f9e43bec63cce5f962d485f8cdd8e55f9ea8486878ba7b",
+        ),
+        (None, "httpd-24-centos7", None),
+        ("quay.io/centos7/", "httpd-24-centos7", ":latest"),
+    ],
+)
+def test_image_sha_bad_uri(registry: str, image: str, sha: str) -> None:
+    uri = [part for part in [registry, image, sha] if part is not None]
+    uri_string = "".join(uri)
+    ret_registry, ret_image, ret_sha = _parse_container_image_uri(uri_string)
+    assert ret_registry is None
+    assert ret_image is None
+    assert ret_sha is None

--- a/exporters/webhook/store/in_memory_metric.py
+++ b/exporters/webhook/store/in_memory_metric.py
@@ -142,7 +142,6 @@ class PelorusGaugeMetricFamily(GaugeMetricFamily):
                 super().add_metric(*args, **kwargs)
                 self.added_metrics.add(metric_id)
 
-    # TODO: Needed?
     def __iter__(self, *args, **kwargs):
         with self.lock:
             for item in super().__iter__(*args, **kwargs):

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.7-rc.4
+VERSION ?= 0.0.7-rc.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -46,8 +46,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.4
-    createdAt: "2023-05-10T17:39:16Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.5
+    createdAt: "2023-05-15T14:13:00Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.7-rc.4
+  name: pelorus-operator.v0.0.7-rc.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -208,26 +208,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - integreatly.org
-          resources:
-          - grafanadashboards
-          - grafanadatasources
-          - grafanas
-          verbs:
-          - '*'
-        - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams
-          verbs:
-          - '*'
-        - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheuses
@@ -255,6 +235,26 @@ spec:
           resources:
           - rolebindings
           - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          - grafanadatasources
+          - grafanas
+          verbs:
+          - '*'
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
           verbs:
           - '*'
         - apiGroups:
@@ -406,7 +406,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.4
+                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -508,7 +508,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.7-rc.4
+  version: 0.0.7-rc.5
   replaces: pelorus-operator.v0.0.6
   skips:
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.7-rc.4
+  newTag: 0.0.7-rc.5

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.4
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.5
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,26 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "apps.openshift.io"
-  resources:
-  - "deploymentconfigs"
-- verbs:
-  - "*"
-  apiGroups:
-  - "integreatly.org"
-  resources:
-  - "grafanadashboards"
-  - "grafanadatasources"
-  - "grafanas"
-- verbs:
-  - "*"
-  apiGroups:
-  - "image.openshift.io"
-  resources:
-  - "imagestreams"
-- verbs:
-  - "*"
-  apiGroups:
   - "monitoring.coreos.com"
   resources:
   - "prometheuses"
@@ -102,5 +82,25 @@ rules:
   resources:
   - "rolebindings"
   - "roles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "apps.openshift.io"
+  resources:
+  - "deploymentconfigs"
+- verbs:
+  - "*"
+  apiGroups:
+  - "integreatly.org"
+  resources:
+  - "grafanadashboards"
+  - "grafanadatasources"
+  - "grafanas"
+- verbs:
+  - "*"
+  apiGroups:
+  - "image.openshift.io"
+  resources:
+  - "imagestreams"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.4
-digest: sha256:04fb28d4a4f31ae5cd881d22cbe0625e628cf80c70740ea89b8f1b8e611a87c2
-generated: "2023-05-10T14:39:11.834761496-03:00"
+  version: 2.0.10-rc.5
+digest: sha256:81bd39a2f18c82e32cf006453b20b0e7bb16b343b10e48a196d480463973ef68
+generated: "2023-05-15T16:12:53.703307825+02:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.4
+  version: 2.0.10-rc.5
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.10-rc.4
+version: 2.0.10-rc.5

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.4
+version: 2.0.10-rc.5

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.4" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.5" }}
             {{- end }}
 
             {{- if .extraEnv }}

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.4" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.5" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}


### PR DESCRIPTION
Rework of deploytime codebase

Move functions to the common openshift library.

Optimize querying for the parent objects such as ReplicaSet and ReplicationController. With this implementation we relay on known api versions and api objects directly from the pod.

Added cache to optimize queries to the OpenShift API for the parent objects. For the running pods we do want to always have the latest state, which means we can't do caching there.

Reworked extracting image SHAs from the running pod instances, which is a base for the skopeo as we also get the full URI of the image.

