### PR TITLE
Skopeo exporter

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.8
+version: 2.0.10-rc.9

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.8
-digest: sha256:352e4f4b90fd81a4e23ff69c4cf49eba63927e3cd29ba72dd9a581b5f6017726
-generated: "2023-06-02T12:09:58.837853721+02:00"
+  version: 2.0.10-rc.9
+digest: sha256:332b336da48d6b79fb023eb0c369dfa669f3250ecaaaa3bdf9db74bb53e0af3f
+generated: "2023-06-05T13:45:09.212650037+02:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.8
+version: 2.0.10-rc.9
 
 dependencies:
   - name: exporters
-    version: 2.0.10-rc.8
+    version: 2.0.10-rc.9
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.8
+version: 2.0.10-rc.9

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/docs/GettingStarted/configuration/ExporterCommittime.md
+++ b/docs/GettingStarted/configuration/ExporterCommittime.md
@@ -2,11 +2,13 @@
 
 The job of the commit time exporter is to find and associate time of the relevant source code commit with a container image SHA built from that source code.
 
-This information can be found in two ways:
+This information can be found in three ways:
 
 - [Git API](#using-commit-time-with-git-apis) making a request to the Git provider
 
-- [Containers' Image](#using-commit-time-with-images) querying `Annotations` or `Labels` within the Image object, without reaching to the git external services. For the image Time provider, the Commit Date must be present as a valid string. This allows to give greater flexibility around 3rd party CI systems used to create container images for the OpenShift running applications.
+- [OpenShift Image Objects](#using-commit-time-with-openshift-image-objects) querying `Annotations` or `Labels` within the OpenShift Image object, without reaching to the git external services. For the `image` Commit Time provider type, the Commit Date must be present as a valid string. This allows to give greater flexibility around 3rd party CI systems used to create container images for the OpenShift running applications.
+
+- [Containers' Image Labels](#using-commit-time-with-containers-image-labels) querying container registry for the OCI `Labels`. For the `containerimage` Commit Time provider type, the Commit Date and Commit Hash must be present as a valid string. This allows to include the Commit Time information at a container build time.
 
 
 Later the Deploy Time Exporter can associate that image SHA with a production deployment and allow to calculate [Lead Time for Change](../../philosophy/outcomes/SoftwareDeliveryPerformance.md#lead-time-for-change) metrics.
@@ -20,23 +22,28 @@ This is the default method of gathering commit time from the source code that tr
 
 We require that all builds associated with a particular application be labeled with the same `app.kubernetes.io/name=<app_name>` label. Different label name may be used with provided exporter instance configuration option [APP_LABEL](#app_label).
 
-In some cases, such as binary build the `Build` object may be missing information required to gather Git commit time. Refer to the [Annotations and local build support](#annotations-and-local-build-support) for information how to enable Commit Time Exporter for such builds.
+In some cases, such as binary build the `Build` object may be missing information required to gather Git commit time. Refer to the [Using Commit Time with OpenShift Image Objects](#using-commit-time-with-openshift-image-objects) or [Using Commit Time with Containers' Image Labels](#using-commit-time-with-containers-image-labels) for information how to enable Commit Time Exporter for such builds.
 
-## Using Commit Time with Images
+## Using Commit Time with OpenShift Image Objects
 
-This is the method of gathering source commit time associated directly with an `Image` object, where `Build` object may be missing.
+This is the method of gathering source commit time associated directly with an OpenShift `Image` object, where `Build` object may be missing.
 
 It may be used in a situations where 3rd party build systems are building container images for our application deployment.
 
-Using Commit Time exporter with images requires setting [PROVIDER](#provider) to `image`, see [example](#example) and synonymously annotating the Image object. Please refer to the [Annotations, Docker Labels and Image support](#annotations-docker-labels-and-image-support) for an detailed workflow example of how to use Commit Time Exporter with Images.
+Using Commit Time exporter with images requires setting [PROVIDER](#provider) to `image`, see [example](#example) and synonymously annotating the Image object. Please refer to the [OpenShift Image Object - Annotations and Labels support](#openshift-image-object-annotations-and-labels-support) for an detailed workflow example of how to use Commit Time Exporter with OpenShift Image Objects.
+
+## Using Commit Time with Containers' Image Labels
+
+This method uses [skopeo](https://github.com/containers/skopeo) to gather commit time information directly from the Container Image that may be in an external registry such as [quay.io](https://quay.io). Using Commit Time exporter with LABELS from container images requires setting [PROVIDER](#provider) to `containerimage`, see [example](#example) and synonymously ensuring proper Container LABEL exists. Please refer to the [Container Image Labels support](#container-image-labels-support) for an detailed workflow example of how to use Commit Time Exporter with Containers' Image Labels.
 
 ## Example
 
-Pelorus configuration object YAML file with three `committime` exporters:
+Pelorus configuration object YAML file with four `committime` exporters:
 
   - First exporter `committime-github` monitors two namespaces `my-application1` and `my-application2`. The source code that was used to build the container images for the running application is hosted in the public [GitHub](https://github.com/) service.
   - Second exporter `committime-exporter2` monitors `my-application3` namespace in which running application is using container image that was built from the bitbucket source code. This source code is on the self-hosted BitBucket service. API to that BitBucket is accessible from `api.bitbucket.mydomain.com`.
-  - Third exporter is using [image](#using-commit-time-with-images) to gather commit date which was used for the deployment directly from the Image annotation `myapp.build.commit.date` that uses date format `%a %b %d %H:%M:%S %Y %z`. This annotation has to be provided by 3rd party systems such as different flavour CI systems. This exporter does not query any external API endpoint.
+  - Third exporter is using [image](#using-commit-time-with-openshift-image-objects) to gather commit date which was used for the deployment directly from the OpenShift Image annotation `myapp.build.commit.date` that uses date format `%a %b %d %H:%M:%S %Y %z`. This annotation has to be provided by 3rd party systems such as different flavour CI systems. This exporter does not query any external API endpoint.
+  - Fourth exporter is using [containerimage](#using-commit-time-with-containers-image-labels) to gather commit date which was used for the deployment directly from the Container Image LABEL `my.custom.commit.date.label` that uses date format `%a %b %d %H:%M:%S %Y %z`. This LABEL within the Container Image has to be provided by 3rd party systems such as different flavour CI systems. This exporter does query an external container registry.
 
 ```yaml
 apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
@@ -79,6 +86,16 @@ spec:
             value: myapp.build.commit.date
           - name: COMMIT_DATE_FORMAT
             value: '%a %b %d %H:%M:%S %Y %z'
+
+      - app_name: committime-exporter4
+        exporter_type: committime
+        extraEnv:
+          - name: PROVIDER
+            value: containerimage
+          - name: COMMIT_DATE_ANNOTATION
+            value: my.custom.commit.date.label
+          - name: COMMIT_DATE_FORMAT
+            value: '%a %b %d %H:%M:%S %Y %z'
 ```
 
 ## Commit Time Exporter configuration options
@@ -86,10 +103,10 @@ spec:
 This is the list of options that can be applied to `env_from_secrets`, `env_from_configmaps` and `extraEnv` section of a Commit time exporter.
 
 Table below represents configuration options, which are valid for any Commit Time Exporter instance.
-There are additional options available when the [PROVIDER](#provider) type is set to `git` or `image`:
+There are additional options available when the [PROVIDER](#provider) type is set to `git`, `image` or `containerimage`:
 
 - [➔ PROVIDER `git` options](#provider-git-options) (same as unset [PROVIDER](#provider) option)
-- [➔ PROVIDER `image` options](#provider-image-options)
+- [➔ PROVIDER `image` and `containerimage` options](#provider-image-and-containerimage-options)
 
 | Variable | Required | Default Value |
 |----------|----------|---------------|
@@ -146,11 +163,12 @@ There are additional options available when the [PROVIDER](#provider) type is se
     - **Default Value:** git
 - **Type:** string
 
-: Provider from which commit date is taken. One of `git`, `image`.
+: Provider from which commit date is taken. One of `git`, `image` or `containerimage`.
 > **NOTE:** For detailed instructions please refer to the:
 >
 - [Using Commit Time with Git APIs](#using-commit-time-with-git-apis) for the `git` PROVIDER
-- [Using Commit Time with Images](#using-commit-time-with-images) for the `image` PROVIDER
+- [Using Commit Time with OpenShift Image Objects](#using-commit-time-with-openshift-image-objects) for the `image` PROVIDER
+- [Using Commit Time with Containers' Image Labels](#using-commit-time-with-image-labels) for the `containerimage` PROVIDER
 
 #### ➔ [PROVIDER](#provider) `git` options
 
@@ -210,9 +228,9 @@ Those options are only applicable to the Commit Time Exporter when the [PROVIDER
 
 : GitHub, Gitea or Azure DevOps API FQDN. This allows the override for Enterprise users.
 
-#### ➔ [PROVIDER](#provider) `image` options
+#### ➔ [PROVIDER](#provider) `image` and `containerimage` options
 
-Those options are only applicable to the Commit Time Exporter when the [PROVIDER](#provider) is set to `image`.
+Those options are only applicable to the Commit Time Exporter when the [PROVIDER](#provider) is set to `image` or `containerimage`.
 
 | Variable | Required | Default Value |
 |----------|----------|---------------|
@@ -222,28 +240,29 @@ Those options are only applicable to the Commit Time Exporter when the [PROVIDER
 ###### COMMIT_DATE_ANNOTATION
 
 - **Required:** no
-    - Only applicable for [PROVIDER](#provider) value: `image`
+    - Only applicable for [PROVIDER](#provider) value: `image` or `containerimage`
     - **Default Value:** io.openshift.build.commit.date
 - **Type:** string
 
-: Annotation name associated with the Image from which commit time is taken.
+: OpenShift Image objects' Annotation name, it's label or Container LABEL from which commit time is taken.
 : 
 > **NOTE:** The date and time found in the OpenShift object [COMMIT_DATE_ANNOTATION](#commit_date_annotation) annotation will be calculated by parsing it's value string in the following order:
 > 
 - 10 digit EPOCH timestamp. Allowed EPOCH string format is one, where milliseconds are ignored.
 - The one from the [COMMIT_DATE_FORMAT](#commit_date_format)
 >
-> Please refer to the [Annotations, Docker Labels and Image support](#annotations-docker-labels-and-image-support) for an example.
+> For the `image` [PROVIDER](#provider) type please refer to the [OpenShift Image Object - Annotations and Labels support](#openshift-image-object-annotations-and-labels-support) for an example.
+> For the `containerimage` [PROVIDER](#provider) type please refer to the [Container Image Labels support](#container-image-labels-support) for an example.
 
 ###### COMMIT_DATE_FORMAT
 
 - **Required:** no
-    - Only applicable for [PROVIDER](#provider) value: `image`
+    - Only applicable for [PROVIDER](#provider) value: `image` or `containerimage`
     - **Default Value:** %a %b %d %H:%M:%S %Y %z
 - **Type:** string
 
 : Used when the format is different then 10 digit EPOCH timestamp.
-: Format in `1989 C standard` to convert time and date found in the Image Label `io.openshift.build.commit.date` or annotation for the Image.
+: Format in `1989 C standard` to convert time and date found in the OpenShift Image Object Label, it's Annotation or Container Image Label `io.openshift.build.commit.date`.
 
 ## Annotations and local build support
 
@@ -294,17 +313,17 @@ oc -n "${NS}" new-app "${NAME}" -l "app.kubernetes.io/name=${NAME}"
 
 There are many ways to build and deploy applications in OpenShift. Additional examples of how to annotate builds such that Pelorus will properly discover the commit metadata can be found in the  [Pelorus tekton demo](https://github.com/dora-metrics/pelorus/tree/master/demo)
 
-## Annotations, Docker Labels and Image support
+## OpenShift Image Object - Annotations and Labels support
 
-Image object annotations similarly to [Annotations and local build support](#annotations-and-local-build-support) may be used for the Commit Time Exporter **where values from the Build objects required to gather commit time from the source repository are missing**.
+OpenShift Image Object annotations similarly to [Annotations and local build support](#annotations-and-local-build-support) may be used for the Commit Time Exporter **where values from the Build objects required to gather commit time from the source repository are missing**.
 
 > **Note:** The requirement to label the image SHA with `app.kubernetes.io/name=<app_name>` for the annotated or Labeled Image objects applies.
 
 Custom Annotation names may also be configured using Commit Time Exporter [COMMIT_DATE_ANNOTATION](#commit_date_annotation) option.
 
-An Image object which is a result of Docker or Source-to-Image (S2I) builds set includes Docker Label `io.openshift.build.commit.date` metadata from which Commit Time Exporter gets the commit date. In such case Image object do not need to be annotated.
+An OpenShift Image Object that is a result of Docker or Source-to-Image (S2I) builds may already include Label `io.openshift.build.commit.date` metadata from which Commit Time Exporter gets the commit date. In such case Image object do not need to be annotated.
 
-Example image metadata with `io.openshift.build.commit.date` Docker Labels and `app.kubernetes.io/name=<app_name>` Label required for the Commit Time Exporter:
+Example of such OpenShift Image Object metadata with `io.openshift.build.commit.date` Labels and `app.kubernetes.io/name=<app_name>` Label required for the Commit Time Exporter:
 
 ```shell
 IMAGE_SHA=588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
@@ -327,7 +346,7 @@ Docker Labels:	io.buildah.version=1.22.4
 		        io.openshift.build.source-location=https://github.com/konveyor/mig-demo-apps.git
 ```
 
-To annotate Image and ensure Commit Time Exporter can gather relevant values, use `oc annotate` CLI as in the following example:
+To annotate an OpenShift Image Object and ensure Commit Time Exporter can gather relevant values, use `oc annotate` CLI as in the following example:
 
 ```shell
 $ NAME=my-application
@@ -367,4 +386,52 @@ $ oc label image "sha256:${IMAGE_SHA}" "app.kubernetes.io/name=${NAME}"
 
 $ oc annotate image "sha256:${IMAGE_SHA}" --overwrite \
      io.openshift.build.commit.date="${EPOCH_TIMESTAMP}"
+```
+
+## Container Image Labels support
+Container Image is another method from which the Commit Time Exporter may gather the commit time information **where values from the Build objects required to gather commit time from the source repository are missing**.
+
+The only requirement is to have appropriate LABELs within the Container Image that was build and it's used for the application deployment.
+
+> **Note:** The requirement to add label to the running application as described in the [Deploy Time Exporter](./ExporterDeploytime.md#) still exists.
+
+Below is sample Container image definition that can be in used by the 3rd party CI to adds such labels to the `quay.io/centos7/httpd-24-centos7` from the current project's `git` folder. We will use pelorus project and LABEL our sample `quay.io/pelorus/httpd-sample-app:latest` Container Image with the latest commit hash and commit date:
+
+```Dockerfile
+FROM quay.io/centos7/httpd-24-centos7
+
+ARG LAST_COMMIT_DATE_TIME
+ARG LAST_COMMIT_SHA
+
+LABEL io.openshift.build.commit.date=${LAST_COMMIT_DATE_TIME}
+LABEL io.openshift.build.commit.id=${LAST_COMMIT_SHA}
+LABEL io.openshift.build.source-location="https://github.com/sclorg/httpd-ex"
+```
+
+To build above example, use any container build method, in this example we will use `podman`.
+
+```shell
+git clone https://github.com/dora-metrics/pelorus
+pushd pelorus/exporters/tests/httpd_docker_with_labels/
+export CONTAINERFILE_LOCATION=./Dockerfile
+export LAST_COMMIT_DATE_TIME=$(git log -1 --format='%ad' --date='format:%a %b %d %H:%M:%S %Y %z')
+export LAST_COMMIT_SHA=$(git rev-parse HEAD)
+
+podman build \
+	    --build-arg LAST_COMMIT_DATE_TIME="$(LAST_COMMIT_DATE_TIME)" \
+	    --build-arg LAST_COMMIT_SHA="$(LAST_COMMIT_SHA)" \
+	    -t quay.io/pelorus/httpd-sample-app:latest \
+      -f "$(CONTAINERFILE_LOCATION)" .
+```
+
+We can see that the Labels are existing within the built container. You can now push this container image to the registry and create OpenShift application that has the appropriate `"app.kubernetes.io/name=${NAME}"` LABEL. That will be sufficient for the `containerimage` Commit Time [PROVIDER](#provider) to work properly.
+
+```shell
+$ podman inspect quay.io/pelorus/httpd-sample-app:latest | jq -r '.[0].Config.Labels'
+{
+  ...
+  "io.openshift.build.commit.date": "Tue May 16 20:07:52 2023 +0200",
+  "io.openshift.build.commit.id": "66f3dc5d6a36afb35e751309207e7c4f137e56b7",
+  ...
+}
 ```

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -67,6 +67,8 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
 
     namespaces: set[str] = field(factory=set, converter=comma_separated(set))
 
+    prod_label: str = field(default=pelorus.DEFAULT_PROD_LABEL)
+
     git_api: Optional[Url] = field(
         default=None,
         converter=attrs.converters.optional(pass_through(Url, Url.parse)),

--- a/exporters/committime/collector_containerimage.py
+++ b/exporters/committime/collector_containerimage.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import json
+import logging
+import queue
+import subprocess
+import threading
+import time
+from typing import Dict, Iterable, Optional, Tuple
+
+from attr import define
+from openshift.dynamic.resource import ResourceField
+
+from committime import CommitMetric
+from committime.collector_base import AbstractCommitCollector
+from pelorus.timeutil import parse_guessing_timezone_DYNAMIC, to_epoch_from_string
+from provider_common.openshift import (
+    filter_pods_by_replica_uid,
+    get_and_log_namespaces,
+    get_images_from_pod,
+    get_running_pods,
+)
+
+skopeo_lock = threading.Lock()
+
+# A queue to store image URI values to be processed
+image_shas_uris_queue = queue.Queue()
+# Use to track if the image is already in the queue
+sha_in_queue = set()
+
+# Cache threshold in seconds, used by our in memory cache or storing image labels.
+# The cache may expire only when the image is not in use by running Pod anymore,
+# so we don't waste the skopeo calls to the external registries, but we still allow
+# pods to be not running for a while before we expire it's metric.
+CACHE_THRESHOLD_1_DAYS = 60 * 60 * 24
+
+# We store skopeo failures and we re-try maximum SKOPEO_MAX_RETRY times per
+# one image URI. This is to prevent too many calls to the external container
+# registries. We have a timeout here, so after some time the failed image URI
+# will be retried anyway. If the pod is not Running anymore the cache expires
+# right away.
+skopeo_failures_lock = threading.Lock()
+# The dictionary where the key is an uuid and the value a Tuple
+# where we store number of retries and the time of last check
+skopeo_failures: Dict[str, Tuple[int, float]] = {}
+SKOPEO_MAX_RETRY = 3
+CACHE_SKOPEO_FAILURE_THRESHOLD_2_DAYS = 60 * 60 * 24 * 2
+
+image_label_cache_lock = threading.Lock()
+image_label_cache: Dict[str, Tuple[Dict, float]] = {}
+
+# Store pods that are running, needed for cleanup
+running_pods_shas_lock = threading.Lock()
+running_pods_shas = set()
+
+
+class SkopeoDataException(Exception):
+    "An error that occurred Skopeo call"
+    pass
+
+
+def _add_to_cleanup_set(sha_256: str) -> None:
+    with running_pods_shas_lock:
+        running_pods_shas.add(sha_256)
+
+
+def _clear_cleanup_set() -> None:
+    with running_pods_shas_lock:
+        running_pods_shas.clear()
+
+
+def _cache_container_images_labels(sha_256: str, labels: Dict) -> None:
+    with image_label_cache_lock:
+        if sha_256 not in image_label_cache:
+            logging.debug(f"Adding SHA256 to the cache: {sha_256} ")
+            image_label_cache[sha_256] = (labels, time.time())
+
+
+def _cleanup_cache() -> None:
+    with running_pods_shas_lock, image_label_cache_lock:
+        current_time = time.time()
+
+        expired_shas = [
+            sha
+            for sha, (_, insertion_time) in image_label_cache.items()
+            if current_time - insertion_time > CACHE_THRESHOLD_1_DAYS
+            and sha not in running_pods_shas
+        ]
+        for sha_256 in expired_shas:
+            image_label_cache.pop(sha_256, None)
+
+
+def _add_skopeo_failure(sha_256: str) -> None:
+    with skopeo_failures_lock:
+        logging.debug(f"Adding SHA256 to the failures: {sha_256} ")
+        if sha_256 not in skopeo_failures:
+            skopeo_failures[sha_256] = (1, time.time())
+        else:
+            skopeo_failures[sha_256] = (skopeo_failures[sha_256][0] + 1, time.time())
+
+
+def _remove_from_skopeo_failure(sha_256: str) -> None:
+    with skopeo_failures_lock:
+        if sha_256 in skopeo_failures:
+            logging.debug(f"Removing SHA256 from the failures: {sha_256} ")
+            skopeo_failures.pop(sha_256, None)
+
+
+def _sha256_valid_to_be_checked(sha_256: str) -> bool:
+    """
+    Checks if the sha256 of an image was previously in
+    failures. If it was then it checks if the number of retries
+    was above threashold.
+
+    If it was then we check if the time treshold was met.
+    """
+    with skopeo_failures_lock:
+        if sha_256 not in skopeo_failures:
+            return True
+
+        no_failures, timestamp = skopeo_failures[sha_256]
+        if no_failures < SKOPEO_MAX_RETRY:
+            return True
+
+    # Must be outside of the failures lock, otherwise we will
+    # deadlock with the _remove_from_skopeo_failure() call
+    if time.time() - timestamp > CACHE_SKOPEO_FAILURE_THRESHOLD_2_DAYS:
+        _remove_from_skopeo_failure(sha_256)
+        return True
+
+    return False
+
+
+def get_labels_from_image(sha_256: str, image_uri: str) -> Dict[str, str]:
+    # Check if the sha_256 is in the failures
+    # and if we should continue based on the SKOPEO_MAX_RETRY
+    # or CACHE_SKOPEO_FAILURE_THRESHOLD_2_DAYS
+    if not _sha256_valid_to_be_checked(sha_256):
+        logging.debug(f"Skipping skopeo for: {sha_256}")
+        raise SkopeoDataException("Sha not to be checked")
+
+    logging.debug(f"Running skopeo for: {sha_256}")
+    command = f"skopeo inspect {image_uri}"
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    output, stderr = process.communicate()
+    output = output.decode("utf-8").strip()
+    if process.returncode != 0:
+        _add_skopeo_failure(sha_256)
+        raise SkopeoDataException(stderr.decode().strip())
+
+    try:
+        image_data = json.loads(output)
+        labels = image_data.get("Labels", {})
+    except json.JSONDecodeError:
+        _add_skopeo_failure(sha_256)
+        raise SkopeoDataException("Error: Invalid JSON output")
+
+    # We got the labels, so remove them from the potential
+    # existence in the failures.
+    _remove_from_skopeo_failure(sha_256)
+    return labels
+
+
+def _skopeo_worker() -> None:
+    loop_count = 1
+    while True:
+        logging.debug(f"Worker loop: {loop_count}")
+        loop_count += 1
+        sha_pop = image_shas_uris_queue.get()
+        try:
+            for sha_256, sha_uri in sha_pop.items():
+                labels = get_labels_from_image(sha_256, sha_uri)
+                _cache_container_images_labels(sha_256, labels)
+        except Exception:
+            # We do not care about the error, but we want to continue
+            # our daemon worker.
+            pass
+
+        image_shas_uris_queue.task_done()
+
+
+# Start the daemon thread which checks for the queue and gathers
+# labels for the queued items.
+skopeo_cache_thread = threading.Thread(target=_skopeo_worker, daemon=True)
+skopeo_cache_thread.start()
+
+
+def _add_image_to_get_label_queue(sha_256: str, image_uri: str) -> None:
+    """
+    Function that puts the sha and corresponding image uri to the queue
+    to be processed by our skopeo worker Thread.
+    """
+
+    with image_label_cache_lock:
+        if sha_256 in image_label_cache:
+            return
+    #    TODO_1: Do not add to queue if already there
+    #    with skopeo_lock:
+    #        if sha_256 in sha_in_queue:
+    #            return
+    logging.debug(f"Adding SHA256 to the SKOPEO queue: {sha_256}")
+    image_shas_uris_queue.put({sha_256: image_uri})
+
+
+def _set_commit_metadata(
+    pod: ResourceField,
+    date_label: str,
+    hash_label: str,
+    sha_256: str,
+    date_format: str = None,
+) -> None:
+    with image_label_cache_lock:
+        labels = image_label_cache.get(sha_256, None)
+        if labels and isinstance(labels, Tuple) and isinstance(labels[0], dict):
+            pod.metadata.commit_hash = labels[0].get(hash_label)
+            commit_time = labels[0].get(date_label)
+            if commit_time:
+                try:
+                    pod.metadata.commit_timestamp = to_epoch_from_string(
+                        commit_time
+                    ).timestamp()
+                except (ValueError, AttributeError):
+                    try:
+                        # Do nothing here as we tried with EPOCH timestamp
+                        pod.metadata.commit_timestamp = parse_guessing_timezone_DYNAMIC(
+                            commit_time, format=date_format
+                        ).timestamp()
+                    except ValueError:
+                        logging.debug(f"Can't get commit timestamp for sha: {sha_256}")
+
+
+@define(kw_only=True)
+class ContainerImageCommitCollector(AbstractCommitCollector):
+    date_format: str
+
+    date_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["commit_time"]
+    hash_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["commit_hash"]
+
+    def get_commit_time(self, metric) -> Optional[CommitMetric]:
+        return super().get_commit_time(metric)
+
+    # overrides collector_base.generate_metric()
+    def generate_metrics(self) -> Iterable[CommitMetric]:
+        metrics = []
+
+        namespaces = get_and_log_namespaces(
+            self.kube_client, self.namespaces, self.prod_label
+        )
+
+        if not namespaces:
+            return metrics
+
+        logging.debug("generate_metrics: start")
+
+        _clear_cleanup_set()
+
+        pods = get_running_pods(self.kube_client, namespaces, self.app_label)
+
+        # Build dictionary with controllers and retrieved pods
+        replica_pods_dict = filter_pods_by_replica_uid(pods)
+
+        for pod in replica_pods_dict.values():
+            # Since a commit will be built into a particular image and there could be multiple
+            # containers (images) per pod, we will push one metric per image/container in the
+            # pod template
+            images = get_images_from_pod(pod)
+
+            for sha, image_uri in images.items():
+                _add_to_cleanup_set(sha)
+                _add_image_to_get_label_queue(sha, image_uri)
+                _set_commit_metadata(
+                    pod,
+                    self.date_annotation_name,
+                    self.hash_annotation_name,
+                    sha,
+                    self.date_format,
+                )
+                if pod.metadata.commit_timestamp and pod.metadata.commit_hash:
+                    metric = CommitMetric(
+                        name=pod.metadata.labels[self.app_label],
+                        namespace=pod.metadata.namespace,
+                        labels=pod.metadata.labels,
+                        commit_hash=pod.metadata.commit_hash,
+                        commit_timestamp=pod.metadata.commit_timestamp,
+                        image_hash=sha,
+                    )
+                    yield metric
+
+        _cleanup_cache()

--- a/exporters/provider_common/openshift.py
+++ b/exporters/provider_common/openshift.py
@@ -301,5 +301,5 @@ def get_images_from_pod(pod: ResourceField) -> Dict[str, str]:
             if sha256_value and registry and image_name:
                 image_shas[
                     sha256_value
-                ] = f"docker://{registry}{image_name}{sha256_value}"
+                ] = f"docker://{registry}{image_name}@{sha256_value}"
     return image_shas

--- a/exporters/tests/data/skopeo_custom_container_labels.json
+++ b/exporters/tests/data/skopeo_custom_container_labels.json
@@ -1,0 +1,90 @@
+{
+    "Name": "quay.io/pelorus/httpd-sample-app",
+    "Digest": "sha256:8065b45e025adff01bae128f669746b9e70ace52b50cf5a72a48b2102ec5089b",
+    "RepoTags": [
+        "latest"
+    ],
+    "Created": "2023-05-17T09:45:54.026075454Z",
+    "DockerVersion": "",
+    "Labels": {
+        "com.redhat.component": "httpd24-container",
+        "description": "Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "io.buildah.version": "1.29.0",
+        "io.k8s.description": "Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "io.k8s.display-name": "Apache httpd 2.4",
+        "custom.commit.date": "Tue May 16 20:07:52 2023 +0200",
+        "custom.commit.id": "66f3dc5d6a36afb35e751309207e7c4f137e56b7",
+        "io.openshift.build.source-location": "https://github.com/dora-metrics/pelorus",
+        "io.openshift.expose-services": "8080:http,8443:https",
+        "io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
+        "io.openshift.tags": "builder,httpd,httpd24",
+        "io.s2i.scripts-url": "image:///usr/libexec/s2i",
+        "maintainer": "SoftwareCollections.org \u003csclorg@redhat.com\u003e",
+        "name": "centos7/httpd-24-centos7",
+        "org.label-schema.build-date": "20200809",
+        "org.label-schema.license": "GPLv2",
+        "org.label-schema.name": "CentOS Base Image",
+        "org.label-schema.schema-version": "1.0",
+        "org.label-schema.vendor": "CentOS",
+        "org.opencontainers.image.created": "2020-08-09 00:00:00+01:00",
+        "org.opencontainers.image.licenses": "GPL-2.0-only",
+        "org.opencontainers.image.title": "CentOS Base Image",
+        "org.opencontainers.image.vendor": "CentOS",
+        "summary": "Platform for running Apache httpd 2.4 or building httpd-based application",
+        "usage": "s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/centos7/httpd-24-centos7 sample-server",
+        "version": "2.4"
+    },
+    "Architecture": "amd64",
+    "Os": "linux",
+    "Layers": [
+        "sha256:c61d16cfe03e7bfb4e7e312f09fb17a815be72096544133320058ee6ce55d0b2",
+        "sha256:10fcbcffb51f81a88d50ed045bbd5818142cd8846a28478b36fb9baeea12b9c2",
+        "sha256:ef467998e3e7687c74c01db07b9ee7fab7c200133d76ab57770b5aac78f5a50c"
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:c61d16cfe03e7bfb4e7e312f09fb17a815be72096544133320058ee6ce55d0b2",
+            "Size": 78951426,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:10fcbcffb51f81a88d50ed045bbd5818142cd8846a28478b36fb9baeea12b9c2",
+            "Size": 10435967,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:ef467998e3e7687c74c01db07b9ee7fab7c200133d76ab57770b5aac78f5a50c",
+            "Size": 50444672,
+            "Annotations": null
+        }
+    ],
+    "Env": [
+        "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
+        "STI_SCRIPTS_PATH=/usr/libexec/s2i",
+        "APP_ROOT=/opt/app-root",
+        "HOME=/opt/app-root/src",
+        "PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "PLATFORM=el7",
+        "HTTPD_VERSION=2.4",
+        "SUMMARY=Platform for running Apache httpd 2.4 or building httpd-based application",
+        "DESCRIPTION=Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/",
+        "HTTPD_APP_ROOT=/opt/app-root",
+        "HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d",
+        "HTTPD_MAIN_CONF_PATH=/etc/httpd/conf",
+        "HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d",
+        "HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d",
+        "HTTPD_TLS_CERT_PATH=/etc/httpd/tls",
+        "HTTPD_VAR_RUN=/var/run/httpd",
+        "HTTPD_DATA_PATH=/var/www",
+        "HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www",
+        "HTTPD_LOG_PATH=/var/log/httpd24",
+        "HTTPD_SCL=httpd24",
+        "BASH_ENV=/opt/app-root/scl_enable",
+        "ENV=/opt/app-root/scl_enable",
+        "PROMPT_COMMAND=. /opt/app-root/scl_enable"
+    ]
+}

--- a/exporters/tests/data/skopeo_default_container_labels.json
+++ b/exporters/tests/data/skopeo_default_container_labels.json
@@ -1,0 +1,90 @@
+{
+    "Name": "quay.io/pelorus/httpd-sample-app",
+    "Digest": "sha256:8065b45e025adff01bae128f669746b9e70ace52b50cf5a72a48b2102ec5089b",
+    "RepoTags": [
+        "latest"
+    ],
+    "Created": "2023-05-17T09:45:54.026075454Z",
+    "DockerVersion": "",
+    "Labels": {
+        "com.redhat.component": "httpd24-container",
+        "description": "Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "io.buildah.version": "1.29.0",
+        "io.k8s.description": "Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "io.k8s.display-name": "Apache httpd 2.4",
+        "io.openshift.build.commit.date": "Tue May 16 20:07:52 2023 +0200",
+        "io.openshift.build.commit.id": "66f3dc5d6a36afb35e751309207e7c4f137e56b7",
+        "io.openshift.build.source-location": "https://github.com/dora-metrics/pelorus",
+        "io.openshift.expose-services": "8080:http,8443:https",
+        "io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
+        "io.openshift.tags": "builder,httpd,httpd24",
+        "io.s2i.scripts-url": "image:///usr/libexec/s2i",
+        "maintainer": "SoftwareCollections.org \u003csclorg@redhat.com\u003e",
+        "name": "centos7/httpd-24-centos7",
+        "org.label-schema.build-date": "20200809",
+        "org.label-schema.license": "GPLv2",
+        "org.label-schema.name": "CentOS Base Image",
+        "org.label-schema.schema-version": "1.0",
+        "org.label-schema.vendor": "CentOS",
+        "org.opencontainers.image.created": "2020-08-09 00:00:00+01:00",
+        "org.opencontainers.image.licenses": "GPL-2.0-only",
+        "org.opencontainers.image.title": "CentOS Base Image",
+        "org.opencontainers.image.vendor": "CentOS",
+        "summary": "Platform for running Apache httpd 2.4 or building httpd-based application",
+        "usage": "s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/centos7/httpd-24-centos7 sample-server",
+        "version": "2.4"
+    },
+    "Architecture": "amd64",
+    "Os": "linux",
+    "Layers": [
+        "sha256:c61d16cfe03e7bfb4e7e312f09fb17a815be72096544133320058ee6ce55d0b2",
+        "sha256:10fcbcffb51f81a88d50ed045bbd5818142cd8846a28478b36fb9baeea12b9c2",
+        "sha256:ef467998e3e7687c74c01db07b9ee7fab7c200133d76ab57770b5aac78f5a50c"
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:c61d16cfe03e7bfb4e7e312f09fb17a815be72096544133320058ee6ce55d0b2",
+            "Size": 78951426,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:10fcbcffb51f81a88d50ed045bbd5818142cd8846a28478b36fb9baeea12b9c2",
+            "Size": 10435967,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:ef467998e3e7687c74c01db07b9ee7fab7c200133d76ab57770b5aac78f5a50c",
+            "Size": 50444672,
+            "Annotations": null
+        }
+    ],
+    "Env": [
+        "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
+        "STI_SCRIPTS_PATH=/usr/libexec/s2i",
+        "APP_ROOT=/opt/app-root",
+        "HOME=/opt/app-root/src",
+        "PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "PLATFORM=el7",
+        "HTTPD_VERSION=2.4",
+        "SUMMARY=Platform for running Apache httpd 2.4 or building httpd-based application",
+        "DESCRIPTION=Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/",
+        "HTTPD_APP_ROOT=/opt/app-root",
+        "HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d",
+        "HTTPD_MAIN_CONF_PATH=/etc/httpd/conf",
+        "HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d",
+        "HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d",
+        "HTTPD_TLS_CERT_PATH=/etc/httpd/tls",
+        "HTTPD_VAR_RUN=/var/run/httpd",
+        "HTTPD_DATA_PATH=/var/www",
+        "HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www",
+        "HTTPD_LOG_PATH=/var/log/httpd24",
+        "HTTPD_SCL=httpd24",
+        "BASH_ENV=/opt/app-root/scl_enable",
+        "ENV=/opt/app-root/scl_enable",
+        "PROMPT_COMMAND=. /opt/app-root/scl_enable"
+    ]
+}

--- a/exporters/tests/data/skopeo_malformed_json_file.json
+++ b/exporters/tests/data/skopeo_malformed_json_file.json
@@ -1,0 +1,6 @@
+Not a proper json
+"Labels": {
+    "custom.commit.date": "Tue May 16 20:07:52 2023 +0200",
+    "custom.commit.id": "66f3dc5d6a36afb35e751309207e7c4f137e56b7",
+}
+

--- a/exporters/tests/data/skopeo_missing_container_labels.json
+++ b/exporters/tests/data/skopeo_missing_container_labels.json
@@ -1,0 +1,87 @@
+{
+    "Name": "quay.io/pelorus/httpd-sample-app",
+    "Digest": "sha256:8065b45e025adff01bae128f669746b9e70ace52b50cf5a72a48b2102ec5089b",
+    "RepoTags": [
+        "latest"
+    ],
+    "Created": "2023-05-17T09:45:54.026075454Z",
+    "DockerVersion": "",
+    "Labels": {
+        "com.redhat.component": "httpd24-container",
+        "description": "Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "io.buildah.version": "1.29.0",
+        "io.k8s.description": "Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "io.k8s.display-name": "Apache httpd 2.4",
+        "io.openshift.expose-services": "8080:http,8443:https",
+        "io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
+        "io.openshift.tags": "builder,httpd,httpd24",
+        "io.s2i.scripts-url": "image:///usr/libexec/s2i",
+        "maintainer": "SoftwareCollections.org \u003csclorg@redhat.com\u003e",
+        "name": "centos7/httpd-24-centos7",
+        "org.label-schema.build-date": "20200809",
+        "org.label-schema.license": "GPLv2",
+        "org.label-schema.name": "CentOS Base Image",
+        "org.label-schema.schema-version": "1.0",
+        "org.label-schema.vendor": "CentOS",
+        "org.opencontainers.image.created": "2020-08-09 00:00:00+01:00",
+        "org.opencontainers.image.licenses": "GPL-2.0-only",
+        "org.opencontainers.image.title": "CentOS Base Image",
+        "org.opencontainers.image.vendor": "CentOS",
+        "summary": "Platform for running Apache httpd 2.4 or building httpd-based application",
+        "usage": "s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/centos7/httpd-24-centos7 sample-server",
+        "version": "2.4"
+    },
+    "Architecture": "amd64",
+    "Os": "linux",
+    "Layers": [
+        "sha256:c61d16cfe03e7bfb4e7e312f09fb17a815be72096544133320058ee6ce55d0b2",
+        "sha256:10fcbcffb51f81a88d50ed045bbd5818142cd8846a28478b36fb9baeea12b9c2",
+        "sha256:ef467998e3e7687c74c01db07b9ee7fab7c200133d76ab57770b5aac78f5a50c"
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:c61d16cfe03e7bfb4e7e312f09fb17a815be72096544133320058ee6ce55d0b2",
+            "Size": 78951426,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:10fcbcffb51f81a88d50ed045bbd5818142cd8846a28478b36fb9baeea12b9c2",
+            "Size": 10435967,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "Digest": "sha256:ef467998e3e7687c74c01db07b9ee7fab7c200133d76ab57770b5aac78f5a50c",
+            "Size": 50444672,
+            "Annotations": null
+        }
+    ],
+    "Env": [
+        "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
+        "STI_SCRIPTS_PATH=/usr/libexec/s2i",
+        "APP_ROOT=/opt/app-root",
+        "HOME=/opt/app-root/src",
+        "PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "PLATFORM=el7",
+        "HTTPD_VERSION=2.4",
+        "SUMMARY=Platform for running Apache httpd 2.4 or building httpd-based application",
+        "DESCRIPTION=Apache httpd 2.4 available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites.",
+        "HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/",
+        "HTTPD_APP_ROOT=/opt/app-root",
+        "HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d",
+        "HTTPD_MAIN_CONF_PATH=/etc/httpd/conf",
+        "HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d",
+        "HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d",
+        "HTTPD_TLS_CERT_PATH=/etc/httpd/tls",
+        "HTTPD_VAR_RUN=/var/run/httpd",
+        "HTTPD_DATA_PATH=/var/www",
+        "HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www",
+        "HTTPD_LOG_PATH=/var/log/httpd24",
+        "HTTPD_SCL=httpd24",
+        "BASH_ENV=/opt/app-root/scl_enable",
+        "ENV=/opt/app-root/scl_enable",
+        "PROMPT_COMMAND=. /opt/app-root/scl_enable"
+    ]
+}

--- a/exporters/tests/httpd_docker_with_labels/Dockerfile
+++ b/exporters/tests/httpd_docker_with_labels/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/centos7/httpd-24-centos7
+
+ARG LAST_COMMIT_DATE_TIME
+ARG LAST_COMMIT_SHA
+
+LABEL io.openshift.build.commit.date=${LAST_COMMIT_DATE_TIME}
+LABEL io.openshift.build.commit.id=${LAST_COMMIT_SHA}
+LABEL io.openshift.build.source-location="https://github.com/dora-metrics/pelorus"

--- a/exporters/tests/test_committime_exporter_containerimage.py
+++ b/exporters/tests/test_committime_exporter_containerimage.py
@@ -1,0 +1,166 @@
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from committime.collector_containerimage import (
+    SkopeoDataException,
+    _cache_container_images_labels,
+    get_labels_from_image,
+    image_label_cache,
+    skopeo_failures,
+)
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+@pytest.fixture
+def mock_popen():
+    with patch("subprocess.Popen") as mock_popen:
+        yield mock_popen
+
+
+def read_skopeo_fake_data(skopeo_response_json_file):
+    with open(TEST_DATA_DIR / skopeo_response_json_file, "rb") as file:
+        return file.read()
+
+
+@pytest.mark.parametrize(
+    "returncode, json_file, expected_labels",
+    [
+        (
+            0,
+            "skopeo_default_container_labels.json",
+            {
+                "io.openshift.build.commit.date": "Tue May 16 20:07:52 2023 +0200",
+                "io.openshift.build.commit.id": "66f3dc5d6a36afb35e751309207e7c4f137e56b7",
+            },
+        ),
+        (
+            0,
+            "skopeo_custom_container_labels.json",
+            {
+                "custom.commit.date": "Tue May 16 20:07:52 2023 +0200",
+                "custom.commit.id": "66f3dc5d6a36afb35e751309207e7c4f137e56b7",
+            },
+        ),
+    ],
+)
+def test_get_labels_from_image(mock_popen, returncode, json_file, expected_labels):
+    mocked_process = Mock()
+    mocked_process.returncode = returncode
+    mocked_process.communicate.return_value = (read_skopeo_fake_data(json_file), b"")
+    mock_popen.return_value = mocked_process
+
+    result = get_labels_from_image("sha256_value", "image_uri")
+
+    for key, value in expected_labels.items():
+        assert key in result and result[key] == value
+
+    command = "skopeo inspect image_uri"
+    subprocess.Popen.assert_called_once_with(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+    )
+    mocked_process.communicate.assert_called_once()
+
+    assert "sha256_value" not in skopeo_failures
+
+
+@pytest.mark.parametrize(
+    "returncode, json_file, missing_labels",
+    [
+        (
+            0,
+            "skopeo_missing_container_labels.json",
+            ["io.openshift.build.commit.date", "io.openshift.build.commit.id"],
+        )
+    ],
+)
+def test_missing_labels_from_image(mock_popen, returncode, json_file, missing_labels):
+    mocked_process = Mock()
+    mocked_process.returncode = returncode
+    mocked_process.communicate.return_value = (read_skopeo_fake_data(json_file), b"")
+    mock_popen.return_value = mocked_process
+
+    result = get_labels_from_image("sha256_value", "image_uri")
+
+    for missing_label in missing_labels:
+        assert missing_label not in result
+
+    command = "skopeo inspect image_uri"
+    subprocess.Popen.assert_called_once_with(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+    )
+    mocked_process.communicate.assert_called_once()
+
+    assert "sha256_value" not in skopeo_failures
+
+
+@pytest.mark.parametrize(
+    "returncode, json_file",
+    [
+        (
+            0,
+            "skopeo_malformed_json_file.json",
+        )
+    ],
+)
+def test_malformed_json_response(mock_popen, returncode, json_file):
+    mocked_process = Mock()
+    mocked_process.returncode = returncode
+    mocked_process.communicate.return_value = (read_skopeo_fake_data(json_file), b"")
+    mock_popen.return_value = mocked_process
+
+    with pytest.raises(SkopeoDataException) as skopeo_exception:
+        get_labels_from_image("sha256_value", "image_uri")
+    assert "Error: Invalid JSON output" in str(skopeo_exception.value)
+
+    command = "skopeo inspect image_uri"
+    subprocess.Popen.assert_called_once_with(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+    )
+    mocked_process.communicate.assert_called_once()
+
+    assert "sha256_value" in skopeo_failures
+
+
+def test_cache_container_images_labels():
+    sha_256 = "sha256_value"
+    labels = {"label1": "value1", "label2": "value2"}
+
+    current_time = time.time()
+
+    with patch("time.time") as mock_time:
+        mock_time.return_value = current_time
+        _cache_container_images_labels(sha_256, labels)
+
+    assert sha_256 in image_label_cache
+    assert image_label_cache[sha_256] == (labels, current_time)

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.7-rc.8
+VERSION ?= 0.0.7-rc.9
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -46,8 +46,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.8
-    createdAt: "2023-06-02T10:10:04Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.9
+    createdAt: "2023-06-05T11:45:14Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.7-rc.8
+  name: pelorus-operator.v0.0.7-rc.9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -406,7 +406,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.8
+                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.9
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -508,7 +508,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.7-rc.8
+  version: 0.0.7-rc.9
   replaces: pelorus-operator.v0.0.6
   skips:
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.7-rc.8
+  newTag: 0.0.7-rc.9

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.8
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.9
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.8
-digest: sha256:352e4f4b90fd81a4e23ff69c4cf49eba63927e3cd29ba72dd9a581b5f6017726
-generated: "2023-06-02T12:09:59.694346599+02:00"
+  version: 2.0.10-rc.9
+digest: sha256:332b336da48d6b79fb023eb0c369dfa669f3250ecaaaa3bdf9db74bb53e0af3f
+generated: "2023-06-05T13:45:09.852506665+02:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.8
+  version: 2.0.10-rc.9
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.10-rc.8
+version: 2.0.10-rc.9

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.8
+version: 2.0.10-rc.9

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

<!-- Use this if merging should auto-close an issue, one issue per line -->
resolves #967

## Description

<!-- Please provide a meaningful description to your PR. Adding its goals and what have you worked on to achieve them is a great way to understand it -->

A new type of provider for the commit time exporter that works similarly to the deploytime, but additionally for the found running applications it reaches out to the external container registry and tries to get commit time from the Docker label.

## Testing Instructions

Currently run the exporter using python interpreter on the system that has skopeo installed:

```
$ export KUBECONFIG=<path to kubeconfig>
$ export LOG_LEVEL=debug
$ export PROVIDER=containerimage
$ export NAMESPACES=<optional step to list namespaces for running pods>
$ python exporters/committime/app.py
$ #Open http://localhost:8080
```
<!-- Please include any additional commands or pointers in addition to our [standard PR testing process](https://pelorus.readthedocs.io/en/latest/Development/#testing-pull-requests) -->

This exporter can be use to calculate the above commit time, based on the provided example application, that is already in the test quay.io repository:

Create ReplicaSet using OCP WebUI or `oc apply` command with the following ReplicaSet in the `testnamespace` namespace, that must be existing:

```yaml
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  name: example
  namespace: testnamespace
spec:
  replicas: 2
  selector:
    matchLabels:
      app: httpd
  template:
    metadata:
      name: httpd
      labels:
        app: httpd
        app.kubernetes.io/name: httpd
    spec:
      containers:
        - name: httpd
          image: >-
            quay.io/pelorus/httpd-sample-app:latest
          ports:
            - containerPort: 8080
```

And start the exporter as above.


You can also create instance of the committime as in the following example (note committime one):

```yaml
apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
kind: Pelorus
metadata:
  name: pelorus-sample
  namespace: test-pelorus-operator
spec:
  exporters:
    instances:
      - enabled: true
        app_name: deploytime-exporter
        exporter_type: deploytime
      - enabled: true
        extraEnv:
          - name: PROVIDER
            value: containerimage
        app_name: committime-exporter
        exporter_type: committime
        image_name: 'quay.io/pelorus/rc-pelorus-exporter:skopeo_8'
    global: {}
  openshift_prometheus_basic_auth_pass: changeme
  openshift_prometheus_htpasswd_auth: 'internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM='
  prometheus_retention: 1y
  prometheus_retention_size: 1GB
  prometheus_storage: false
  prometheus_storage_pvc_capacity: 2Gi
  prometheus_storage_pvc_storageclass: gp2
```