### PR TITLE
feat: Add fallback option when Jira exporter can not determine application

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.5
+version: 2.0.10-rc.6

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.5
-digest: sha256:81bd39a2f18c82e32cf006453b20b0e7bb16b343b10e48a196d480463973ef68
-generated: "2023-05-15T16:12:35.760966639+02:00"
+  version: 2.0.10-rc.6
+digest: sha256:cb161faa5586bbb5112e63c731f0178f1d611529687225eb570ae1a49c1e6bd6
+generated: "2023-05-31T09:55:35.954667465-03:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.5
+version: 2.0.10-rc.6
 
 dependencies:
   - name: exporters
-    version: 2.0.10-rc.5
+    version: 2.0.10-rc.6
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.5
+version: 2.0.10-rc.6

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.5" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.6" }}
             {{- end }}
 
             {{- if .extraEnv }}

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.5" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.6" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -56,6 +56,7 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 | [API_USER](#api_user) | no | - |
 | [TOKEN](#token) | yes | - |
 | [APP_LABEL](#app_label) | no | `app.kubernetes.io/name` |
+| [APP_NAME](#app_name) | no | - |
 | [APP_FIELD](#app_field) | no | `u_application` |
 | [PROJECTS](#projects) | no | - |
 | [PELORUS_DEFAULT_KEYWORD](#pelorus_default_keyword) | no | `default` |
@@ -116,6 +117,13 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 - **Type:** string
 
 : Changes the label used to identify applications.
+###### APP_NAME
+
+- **Required:** no
+    - Only applicable for [PROVIDER](#provider) set to `jira`
+- **Type:** string
+
+: Set `unknown` application to desired value.
 
 ###### APP_FIELD
 

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -117,13 +117,14 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 - **Type:** string
 
 : Changes the label used to identify applications.
+
 ###### APP_NAME
 
 - **Required:** no
     - Only applicable for [PROVIDER](#provider) set to `jira`
 - **Type:** string
 
-: Set `unknown` application to desired value.
+: Set fallback option when Jira exporter can not determine application related to collected issues. Otherwise, applications that can not be determined from issues are stored as `unknown` and do not appear in Grafana dashboards.
 
 ###### APP_FIELD
 

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -282,6 +282,5 @@ class JiraFailureCollector(AbstractFailureCollector):
             if label.startswith(matcher):
                 return label.replace(matcher, "")
         if self.app_name is None:
-            # TODO set this behavior to all failure exporters?
             return "unknown"
         return self.app_name

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -88,6 +88,8 @@ class JiraFailureCollector(AbstractFailureCollector):
 
     query_result_fields_string: str = field(default=QUERY_RESULT_FIELDS, init=False)
 
+    app_name: Optional[str] = field(default=None, metadata=env_vars("APP_NAME"))
+
     def __attrs_post_init__(self):
         # Do not mix projects with custom JQL query
         # Gather all fields and projects
@@ -279,4 +281,7 @@ class JiraFailureCollector(AbstractFailureCollector):
             matcher = f"{self.app_label}="
             if label.startswith(matcher):
                 return label.replace(matcher, "")
-        return "unknown"
+        if self.app_name is None:
+            # TODO set this behavior to all failure exporters?
+            return "unknown"
+        return self.app_name

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.7-rc.5
+VERSION ?= 0.0.7-rc.6
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -46,8 +46,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.5
-    createdAt: "2023-05-15T14:13:00Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.6
+    createdAt: "2023-05-31T12:55:40Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.7-rc.5
+  name: pelorus-operator.v0.0.7-rc.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -208,20 +208,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - prometheuses
-          - prometheusrules
-          - servicemonitors
-          verbs:
-          - '*'
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - '*'
-        - apiGroups:
           - ""
           resources:
           - configmaps
@@ -255,6 +241,20 @@ spec:
           - image.openshift.io
           resources:
           - imagestreams
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheuses
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
           verbs:
           - '*'
         - apiGroups:
@@ -406,7 +406,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.5
+                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.6
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -508,7 +508,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.7-rc.5
+  version: 0.0.7-rc.6
   replaces: pelorus-operator.v0.0.6
   skips:
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.7-rc.5
+  newTag: 0.0.7-rc.6

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.5
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.6
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,20 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "monitoring.coreos.com"
-  resources:
-  - "prometheuses"
-  - "prometheusrules"
-  - "servicemonitors"
-- verbs:
-  - "*"
-  apiGroups:
-  - "route.openshift.io"
-  resources:
-  - "routes"
-- verbs:
-  - "*"
-  apiGroups:
   - ""
   resources:
   - "configmaps"
@@ -102,5 +88,19 @@ rules:
   - "image.openshift.io"
   resources:
   - "imagestreams"
+- verbs:
+  - "*"
+  apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - "prometheuses"
+  - "prometheusrules"
+  - "servicemonitors"
+- verbs:
+  - "*"
+  apiGroups:
+  - "route.openshift.io"
+  resources:
+  - "routes"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.5
-digest: sha256:81bd39a2f18c82e32cf006453b20b0e7bb16b343b10e48a196d480463973ef68
-generated: "2023-05-15T16:12:53.703307825+02:00"
+  version: 2.0.10-rc.6
+digest: sha256:cb161faa5586bbb5112e63c731f0178f1d611529687225eb570ae1a49c1e6bd6
+generated: "2023-05-31T09:55:36.290173474-03:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.5
+  version: 2.0.10-rc.6
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.10-rc.5
+version: 2.0.10-rc.6

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.5
+version: 2.0.10-rc.6

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.5" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.10-rc.6" }}
             {{- end }}
 
             {{- if .extraEnv }}

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.5" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.6" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

resolves #994

## Description

Add fallback option when Pelorus can not determine `app_name` from issue.

## Testing Instructions

Create Pelorus failure exporter using
```yaml
apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
kind: Pelorus
metadata:
  name: test-app-name-option
spec:
  exporters:
    instances:
      - app_name: failure-exporter
        exporter_type: failure
        extraEnv:
          - name: API_USER
            value: jira_user
          - name: TOKEN
            value: jira_token
          - name: SERVER
            value: https://pelorustest.atlassian.net
          - name: APP_NAME
            value: robotron
          - name: PROJECTS
            value: 'Test,pelorus_tekton_test,todolist-mongo'
          - name: JIRA_RESOLVED_STATUS
            value: DONE
```
and check that no issues are related to app "unknown" and app "robotron" appears in Grafana, using Operator commented by CI.
