### PR TITLE
Add Timestamp to the Failure exporter

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.7
+version: 2.0.10-rc.8

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.7
-digest: sha256:2f4e5d396ce969b340d2768035737200c05ac074dc05aa109d737bfb336c07bb
-generated: "2023-05-31T17:19:59.256186361-03:00"
+  version: 2.0.10-rc.8
+digest: sha256:352e4f4b90fd81a4e23ff69c4cf49eba63927e3cd29ba72dd9a581b5f6017726
+generated: "2023-06-02T12:09:58.837853721+02:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.7
+version: 2.0.10-rc.8
 
 dependencies:
   - name: exporters
-    version: 2.0.10-rc.7
+    version: 2.0.10-rc.8
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.7
+version: 2.0.10-rc.8

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.7" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.7" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/templates/prometheus-rules.yaml
+++ b/charts/pelorus/templates/prometheus-rules.yaml
@@ -20,7 +20,7 @@ spec:
         avg(sdp:lead_time:by_app)
     - record: sdp:time_to_restore:by_issue
       expr: >
-        failure_resolution_timestamp{app!="unknown"} - failure_creation_timestamp{app!="unknown"}
+        failure_resolution_timestamp{app!="unknown"} - max_over_time(failure_creation_timestamp{app!="unknown"}[5y])
     - record: sdp:time_to_restore:by_app
       expr: >
         avg by (app) (sdp:time_to_restore:by_issue)

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -1,6 +1,10 @@
 # Failure Time Exporter
 
-Failure time exporter captures the timestamp at which a failure occurred, in a production environment, and when it was resolved. It does this by parsing the information of when the issue was created, and closed, in the Issue Tracker(s).
+Failure time exporter captures the timestamps at which a broken deployment occurred, and when it was fixed. It does this by parsing the information of when the issue related to that broken deployment was created, and closed, in the Issue Tracker(s).
+
+The Failure Time Exporter configuration should be adjusted based on the backend being used to restrict failures to only those related to failed deployments in a production.
+
+Failure exporter only collects failure events that are less than 30 minutes old. Older failures won't be included unless they have been already collected.
 
 Failure Time Exporter may be deployed with one of the [supported Issues Trackers](../Overview.md#issue-trackers). In one clusters' namespace there may be multiple instances of Failure Time Exporter, one for each provider (or each project). Each provider requires specific [configuration](#failureconfigmap).
 

--- a/docs/GettingStarted/configuration/ExporterWebhook.md
+++ b/docs/GettingStarted/configuration/ExporterWebhook.md
@@ -110,6 +110,8 @@ For the Header X-Pelorus-Event: `committime`
 ##### failure
 For the Header X-Pelorus-Event: `failure`
 
+> **NOTE:** To align with the nature of Prometheus, it is required that the failure event being sent to the webhook exporter should not have occurred more than 30 minutes prior to the time of sending.
+
 | Key             | Type     | Description |
 |-----------------|----------|-------------|
 | `app`           | `string` | Monitored application name |

--- a/exporters/webhook/app.py
+++ b/exporters/webhook/app.py
@@ -130,11 +130,17 @@ async def prometheus_metric(received_metric: PelorusMetric):
 
         if failure_type == FailurePelorusPayload.FailureEvent.CREATED:
             in_memory_failure_creation_metric.add_metric(
-                metric_id, prometheus_metric, metric.timestamp
+                metric_id,
+                prometheus_metric,
+                metric.timestamp,
+                timestamp=metric.timestamp,
             )
         elif failure_type == FailurePelorusPayload.FailureEvent.RESOLVED:
             in_memory_failure_resolution_metric.add_metric(
-                metric_id, prometheus_metric, metric.timestamp
+                metric_id,
+                prometheus_metric,
+                metric.timestamp,
+                timestamp=metric.timestamp,
             )
         else:
             logging.error(f"Failure Metric {metric} can not be stored")

--- a/exporters/webhook/models/pelorus_webhook.py
+++ b/exporters/webhook/models/pelorus_webhook.py
@@ -102,6 +102,14 @@ class FailurePelorusPayload(PelorusPayload):
     failure_id: str  # It's an str, because issue may be mix of str and int, e.g. Issue-1
     failure_event: FailureEvent
 
+    @validator("timestamp")
+    def accepted_timestamp_therashold(cls, v):
+        if is_out_of_date(str(v)):
+            raise ValueError(
+                f"Timestamp cannot be older than {METRIC_TIMESTAMP_THRESHOLD_MINUTES} minutes"
+            )
+        return v
+
 
 class DeployTimePelorusPayload(PelorusPayload):
     """

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.7-rc.7
+VERSION ?= 0.0.7-rc.8
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -46,8 +46,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.7
-    createdAt: "2023-05-31T20:20:02Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.8
+    createdAt: "2023-06-02T10:10:04Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.7-rc.7
+  name: pelorus-operator.v0.0.7-rc.8
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -208,6 +208,27 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          - grafanadatasources
+          - grafanas
+          verbs:
+          - '*'
+        - apiGroups:
           - image.openshift.io
           resources:
           - imagestreams
@@ -234,27 +255,6 @@ spec:
           - secrets
           - serviceaccounts
           - services
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - integreatly.org
-          resources:
-          - grafanadashboards
-          - grafanadatasources
-          - grafanas
           verbs:
           - '*'
         - apiGroups:
@@ -406,7 +406,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.7
+                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.8
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -508,7 +508,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.7-rc.7
+  version: 0.0.7-rc.8
   replaces: pelorus-operator.v0.0.6
   skips:
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.7-rc.7
+  newTag: 0.0.7-rc.8

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.7
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.8
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,27 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "rolebindings"
+  - "roles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "apps.openshift.io"
+  resources:
+  - "deploymentconfigs"
+- verbs:
+  - "*"
+  apiGroups:
+  - "integreatly.org"
+  resources:
+  - "grafanadashboards"
+  - "grafanadatasources"
+  - "grafanas"
+- verbs:
+  - "*"
+  apiGroups:
   - "image.openshift.io"
   resources:
   - "imagestreams"
@@ -81,26 +102,5 @@ rules:
   - "secrets"
   - "serviceaccounts"
   - "services"
-- verbs:
-  - "*"
-  apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  - "rolebindings"
-  - "roles"
-- verbs:
-  - "*"
-  apiGroups:
-  - "apps.openshift.io"
-  resources:
-  - "deploymentconfigs"
-- verbs:
-  - "*"
-  apiGroups:
-  - "integreatly.org"
-  resources:
-  - "grafanadashboards"
-  - "grafanadatasources"
-  - "grafanas"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.7
-digest: sha256:2f4e5d396ce969b340d2768035737200c05ac074dc05aa109d737bfb336c07bb
-generated: "2023-05-31T17:19:59.404951836-03:00"
+  version: 2.0.10-rc.8
+digest: sha256:352e4f4b90fd81a4e23ff69c4cf49eba63927e3cd29ba72dd9a581b5f6017726
+generated: "2023-06-02T12:09:59.694346599+02:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.7
+  version: 2.0.10-rc.8
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.10-rc.7
+version: 2.0.10-rc.8

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.7
+version: 2.0.10-rc.8

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.7" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.7" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.8" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-rules.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-rules.yaml
@@ -20,7 +20,7 @@ spec:
         avg(sdp:lead_time:by_app)
     - record: sdp:time_to_restore:by_issue
       expr: >
-        failure_resolution_timestamp{app!="unknown"} - failure_creation_timestamp{app!="unknown"}
+        failure_resolution_timestamp{app!="unknown"} - max_over_time(failure_creation_timestamp{app!="unknown"}[5y])
     - record: sdp:time_to_restore:by_app
       expr: >
         avg by (app) (sdp:time_to_restore:by_issue)


### PR DESCRIPTION
Adding Timestamp to the Failure exporter is important to properly calculate Change Failure Rate Over Time (CFR)

The CFR metric is a simple number that represents the number of failed deployments to the number of all deployments. As such without the timestamp we were adding the Failures to the previously known ones and never calculating properly based on a chosen time window.

The max_over_time is required to be able to deduct creation time of the failure from the resolution time of that failure to properly calculate Mean Time to Restore and other metrics. Without that we would almost never had the time window that both metrics create/failure would be within it and as such the deduction would return nothing.

- [ ] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

<!-- Use this if merging should auto-close an issue, one issue per line -->
resolves #1010

## Testing Instructions

Use script provided in the #1010 to test the scenario.