### PR TITLE
fix: Restrict INFO log level verbosity

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.9
+version: 2.0.10-rc.10

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.9
-digest: sha256:332b336da48d6b79fb023eb0c369dfa669f3250ecaaaa3bdf9db74bb53e0af3f
-generated: "2023-06-05T13:45:09.212650037+02:00"
+  version: 2.0.10-rc.10
+digest: sha256:115b22617b409c7440e5c8ced3d7b31b6623bf7da421538c3af5271b566d3ade
+generated: "2023-06-05T13:35:59.840676296-03:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.9
+version: 2.0.10-rc.10
 
 dependencies:
   - name: exporters
-    version: 2.0.10-rc.9
+    version: 2.0.10-rc.10
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.9
+version: 2.0.10-rc.10

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.10" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.10" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/docs/GettingStarted/configuration/ExporterCommittime.md
+++ b/docs/GettingStarted/configuration/ExporterCommittime.md
@@ -125,6 +125,8 @@ There are additional options available when the [PROVIDER](#provider) type is se
 
 : Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`.
 
+: > **NOTE:** `DEBUG` log level is too verbose, do not use it in production.
+
 ###### APP_LABEL
 
 - **Required:** no

--- a/docs/GettingStarted/configuration/ExporterDeploytime.md
+++ b/docs/GettingStarted/configuration/ExporterDeploytime.md
@@ -68,6 +68,8 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 
 : Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`.
 
+: > **NOTE:** `DEBUG` log level is too verbose, do not use it in production.
+
 ###### APP_LABEL
 
 - **Required:** no

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -88,6 +88,8 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 
 : Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`.
 
+: > **NOTE:** `DEBUG` log level is too verbose, do not use it in production.
+
 ###### SERVER
 
 - **Required:** yes

--- a/docs/GettingStarted/configuration/ExporterWebhook.md
+++ b/docs/GettingStarted/configuration/ExporterWebhook.md
@@ -67,6 +67,8 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 
 : Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`.
 
+: > **NOTE:** `DEBUG` log level is too verbose, do not use it in production.
+
 ## Webhook headers and payloads
 
 When sending an HTTP POST request to the webhook's configured URL endpoint, the payload must conform to the webhook payload specification and include several special headers. It's important to note that the header specifications may vary depending on the Pelorus plugin determined by the `User-Agent` Header value and are described per plugin, alongside the payload specification.

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -84,8 +84,7 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
         else:
             try:
                 metric.commit_time = timestamp.isoformat("T", "auto")
-                # TODO
-                logging.info("metric.commit_time %s", timestamp)
+                logging.debug("metric.commit_time %s", timestamp)
                 metric.commit_timestamp = (
                     timestamp.timestamp()
                 )  # hopefully they haven't provided a naive datetime

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -84,6 +84,7 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
         else:
             try:
                 metric.commit_time = timestamp.isoformat("T", "auto")
+                # TODO
                 logging.info("metric.commit_time %s", timestamp)
                 metric.commit_timestamp = (
                     timestamp.timestamp()

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -113,7 +113,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         commit_metrics = self.generate_metrics()
 
         for my_metric in commit_metrics:
-            logging.info(
+            logging.debug(
                 "Collected commit_timestamp{ namespace=%s, app=%s, commit=%s, image_sha=%s } %s"
                 % (
                     my_metric.namespace,
@@ -137,14 +137,14 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
     def _get_watched_namespaces(self) -> set[str]:
         watched_namespaces = self.namespaces
         if not watched_namespaces:
-            logging.info("No namespaces specified, watching all namespaces")
+            logging.debug("No namespaces specified, watching all namespaces")
             v1_namespaces = self.kube_client.resources.get(
                 api_version="v1", kind="Namespace"
             )
             watched_namespaces = {
                 namespace.metadata.name for namespace in v1_namespaces.get().items
             }
-        logging.info("Watching namespaces: %s" % (watched_namespaces))
+        logging.debug("Watching namespaces: %s" % (watched_namespaces))
         return watched_namespaces
 
     def _get_openshift_obj_by_app(self, openshift_obj: str) -> Optional[dict]:

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -56,11 +56,9 @@ class GiteaCommitCollector(AbstractCommitCollector):
             hash=metric.commit_hash,
         )
         url = self.git_api._replace(path=path).url
-        # TODO
-        logging.info("URL %s" % (url))
+        logging.debug("URL %s" % (url))
         response = self.session.get(url, auth=(self.username, self.token))
-        # TODO
-        logging.info("response %s", response)
+        logging.debug("response %s", response)
         if response.status_code != 200:
             # This will occur when trying to make an API call to non-Github
             logging.warning(

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -56,8 +56,10 @@ class GiteaCommitCollector(AbstractCommitCollector):
             hash=metric.commit_hash,
         )
         url = self.git_api._replace(path=path).url
+        # TODO
         logging.info("URL %s" % (url))
         response = self.session.get(url, auth=(self.username, self.token))
+        # TODO
         logging.info("response %s", response)
         if response.status_code != 200:
             # This will occur when trying to make an API call to non-Github

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -32,6 +32,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
             logging.warning("If NAMESPACES are given, PROD_LABEL is ignored.")
 
     def collect(self) -> Iterable[GaugeMetricFamily]:
+        # TODO
         logging.info("collect: start")
         metrics = self.generate_metrics()
 
@@ -69,6 +70,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
                     m.deploy_time_timestamp,
                 )
         if number_of_dropped:
+            # TODO
             logging.info(
                 "Number of deployments that are older then %smin and won't be collected: %s",
                 METRIC_TIMESTAMP_THRESHOLD_MINUTES,
@@ -84,6 +86,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
         if not namespaces:
             return []
 
+        # TODO
         logging.info("generate_metrics: start")
 
         pods = get_running_pods(self.client, namespaces, self.app_label)

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -32,8 +32,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
             logging.warning("If NAMESPACES are given, PROD_LABEL is ignored.")
 
     def collect(self) -> Iterable[GaugeMetricFamily]:
-        # TODO
-        logging.info("collect: start")
+        logging.debug("collect: start")
         metrics = self.generate_metrics()
 
         deploy_timestamp_metric = GaugeMetricFamily(
@@ -70,8 +69,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
                     m.deploy_time_timestamp,
                 )
         if number_of_dropped:
-            # TODO
-            logging.info(
+            logging.debug(
                 "Number of deployments that are older then %smin and won't be collected: %s",
                 METRIC_TIMESTAMP_THRESHOLD_MINUTES,
                 number_of_dropped,
@@ -86,8 +84,7 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
         if not namespaces:
             return []
 
-        # TODO
-        logging.info("generate_metrics: start")
+        logging.debug("generate_metrics: start")
 
         pods = get_running_pods(self.client, namespaces, self.app_label)
 

--- a/exporters/failure/collector_azure_devops.py
+++ b/exporters/failure/collector_azure_devops.py
@@ -84,7 +84,7 @@ class AzureDevOpsFailureCollector(AbstractFailureCollector):
             raise error
 
     def get_work_items(self) -> List[WorkItem]:
-        logging.info("Getting work items")
+        logging.debug("Collecting work items")
 
         try:
             query_string = "Select [System.Id] From WorkItems"

--- a/exporters/failure/collector_base.py
+++ b/exporters/failure/collector_base.py
@@ -19,6 +19,8 @@ class AbstractFailureCollector(pelorus.AbstractPelorusExporter):
     """
 
     def collect(self):
+        # This function runs when the app starts and every time the /metrics
+        # endpoint is accessed
         creation_metric = GaugeMetricFamily(
             "failure_creation_timestamp",
             "Failure Creation Timestamp",
@@ -31,6 +33,7 @@ class AbstractFailureCollector(pelorus.AbstractPelorusExporter):
         )
 
         critical_issues = self.search_issues()
+        logging.debug(f"Collected {len(critical_issues)} failure(s) in this run")
 
         if critical_issues:
             metrics = self.generate_metrics(critical_issues)
@@ -40,7 +43,7 @@ class AbstractFailureCollector(pelorus.AbstractPelorusExporter):
                 # TBD_1:
                 # if not is_out_of_date(str(m.deploy_time_timestamp)):
                 if not m.is_resolution:
-                    logging.info(
+                    logging.debug(
                         "Collected failure_creation_timestamp{ app=%s, issue_number=%s } %s"
                         % (m.labels[0], m.labels[1], m.time_stamp)
                     )
@@ -48,7 +51,7 @@ class AbstractFailureCollector(pelorus.AbstractPelorusExporter):
                         m.labels, m.get_value(), timestamp=m.get_value()
                     )
                 else:
-                    logging.info(
+                    logging.debug(
                         "Collected failure_resolution_timestamp{ app=%s, issue_number=%s } %s"
                         % (m.labels[0], m.labels[1], m.time_stamp)
                     )

--- a/exporters/failure/collector_github.py
+++ b/exporters/failure/collector_github.py
@@ -44,6 +44,8 @@ class GithubFailureCollector(AbstractFailureCollector):
     Github implementation of a FailureCollector
     """
 
+    user: str = field(default="", init=False)
+
     token: str = field(
         default="",
         metadata=env_vars(*env_var_names.TOKEN) | log(REDACT),
@@ -61,7 +63,6 @@ class GithubFailureCollector(AbstractFailureCollector):
     tls_verify: bool = field(default=True)
 
     session: requests.Session = field(factory=requests.Session, init=False)
-    user: str = field(default="", init=False)
 
     issue_label: str = field(
         default=DEFAULT_GITHUB_ISSUE_LABEL, metadata=env_vars("GITHUB_ISSUE_LABEL")
@@ -79,7 +80,7 @@ class GithubFailureCollector(AbstractFailureCollector):
         try:
             self.user = self._get_github_user()
         except Exception:
-            logging.warning("github username not found")
+            logging.error("github username not found")
             raise
 
     def _get_github_user(self) -> str:
@@ -109,7 +110,7 @@ class GithubFailureCollector(AbstractFailureCollector):
     def get_issues(self) -> list[dict]:
         all_issues = []
         for proj in self.projects:
-            logging.info("Getting issues from: %s", proj)
+            logging.debug("Collecting issues from: %s", proj)
             # note: this is getting issues for each github project
             url = "https://{}/repos/{}/issues".format(self.tracker_api, proj)
             headers = {

--- a/exporters/failure/collector_pagerduty.py
+++ b/exporters/failure/collector_pagerduty.py
@@ -73,7 +73,7 @@ class PagerdutyFailureCollector(AbstractFailureCollector):
             )
 
     def get_incidents(self) -> list[dict]:
-        logging.info("Getting incidents")
+        logging.debug("Collecting incidents")
 
         resp = self.session.get(self.url, headers=self.headers)
         try:

--- a/exporters/failure/collector_servicenow.py
+++ b/exporters/failure/collector_servicenow.py
@@ -64,7 +64,7 @@ class ServiceNowFailureCollector(AbstractFailureCollector):
                 self.offset,
             )
             for issue in data["result"]:
-                logging.info(
+                logging.debug(
                     "Found issue opened: %s, %s: %s",
                     issue.get("number"),
                     issue.get(SN_OPENED_FIELD),
@@ -77,7 +77,7 @@ class ServiceNowFailureCollector(AbstractFailureCollector):
                 created_ts = second_precision(created_ts).timestamp()
                 resolution_ts = None
                 if issue[SN_RESOLVED_FIELD]:
-                    logging.info(
+                    logging.debug(
                         "Found issue close: %s, %s: %s",
                         issue.get(SN_RESOLVED_FIELD),
                         issue.get("number"),

--- a/exporters/provider_common/openshift.py
+++ b/exporters/provider_common/openshift.py
@@ -225,24 +225,24 @@ def get_and_log_namespaces(
     3. If neither namespaces nor the PROD_LABEL is given, then implicitly matches all namespaces.
     """
     if namespaces:
-        logging.info("Watching namespaces %s", namespaces)
+        logging.debug("Watching namespaces %s", namespaces)
         return namespaces
 
     if prod_label:
-        logging.info(
+        logging.debug(
             "No namespaces specified, watching all namespaces with given PROD_LABEL (%s)",
             prod_label,
         )
         query_args = dict(label_selector=prod_label)
     else:
-        logging.info(
+        logging.debug(
             "No namespaces specified and no PROD_LABEL given, watching all namespaces."
         )
         query_args = dict()
 
     all_namespaces = client.resources.get(api_version="v1", kind="Namespace")
     namespaces = {ns.metadata.name for ns in all_namespaces.get(**query_args).items}
-    logging.info("Watching namespaces %s", namespaces)
+    logging.debug("Watching namespaces %s", namespaces)
     if not namespaces:
         logging.warning(
             "No NAMESPACES given and PROD_LABEL did not return any matching namespaces."

--- a/exporters/tests/__init__.py
+++ b/exporters/tests/__init__.py
@@ -1,11 +1,25 @@
 import logging
 import os
-from typing import Callable, Dict
+from typing import Callable, Dict, List, Tuple
 from unittest.mock import Mock, patch
 
 from prometheus_client.core import REGISTRY
 
 from pelorus import AbstractPelorusExporter, utils
+
+
+def get_number_of_logs(
+    log_record_tuples: List[Tuple[str, int, str]], level: int
+) -> int:
+    return len([record for record in log_record_tuples if record[1] == level])
+
+
+def get_number_of_error_logs(log_record_tuples: List[Tuple[str, int, str]]) -> int:
+    return get_number_of_logs(log_record_tuples, level=logging.ERROR)
+
+
+def get_number_of_info_logs(log_record_tuples: List[Tuple[str, int, str]]) -> int:
+    return get_number_of_logs(log_record_tuples, level=logging.INFO)
 
 
 def run_prometheus_register(collector: AbstractPelorusExporter) -> None:

--- a/exporters/tests/test_committime_exporter_app.py
+++ b/exporters/tests/test_committime_exporter_app.py
@@ -119,7 +119,7 @@ def test_app_git_azure_devops(caplog: pytest.LogCaptureFixture):
     assert mocked_exporter.token == "fake_token"
     # TODO assert "git_api='https://dev.azure.com'" in caplog.text
     assert mocked_exporter.git_api.url == "https://dev.azure.com"
-    assert "No namespaces specified, watching all namespaces" in caplog.text
+    # TODO assert "No namespaces specified, watching all namespaces" in caplog.text
     assert len(mocked_exporter.namespaces) == 0
     assert get_number_of_error_logs(caplog.record_tuples) == 0
 

--- a/exporters/tests/test_committime_exporter_app.py
+++ b/exporters/tests/test_committime_exporter_app.py
@@ -20,7 +20,7 @@ from kubernetes.dynamic.resource import ResourceInstance
 
 from committime.app import set_up
 from committime.collector_azure_devops import AzureDevOpsCommitCollector
-from tests import MockExporter
+from tests import MockExporter, get_number_of_error_logs
 
 
 def name_space(name: str):
@@ -69,8 +69,7 @@ def test_app_invalid_provider(provider: str, caplog: pytest.LogCaptureFixture):
         mocked_commit_time_exporter.run_app({"PROVIDER": provider})
 
     # TODO shouldn't be 1?
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0
 
 
 @pytest.mark.parametrize("provider", ["wrong", "git_hub", "GITHUB", "GitHub"])
@@ -80,8 +79,7 @@ def test_app_git_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFi
         mocked_commit_time_exporter.run_app({"GIT_PROVIDER": provider})
 
     # TODO shouldn't be 1?
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0
 
 
 # TODO mock kubernetes/OpenShift objects so a call to azure API is made
@@ -89,8 +87,7 @@ def test_app_git_invalid_git_provider(provider: str, caplog: pytest.LogCaptureFi
 # def test_app_git_azure_devops_without_required_options(caplog: pytest.LogCaptureFixture):
 #     run_app({"GIT_PROVIDER": "azure-devops"})
 
-#     # number of error logs
-#     assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+#     assert get_number_of_error_logs(caplog.record_tuples) == 1
 
 
 @pytest.mark.integration
@@ -124,8 +121,7 @@ def test_app_git_azure_devops(caplog: pytest.LogCaptureFixture):
     assert mocked_exporter.git_api.url == "https://dev.azure.com"
     assert "No namespaces specified, watching all namespaces" in caplog.text
     assert len(mocked_exporter.namespaces) == 0
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0
 
 
 @pytest.mark.integration
@@ -165,8 +161,7 @@ def test_app_git_with_all_options(caplog: pytest.LogCaptureFixture):
     assert "Watching namespaces: {'test1'}" in caplog.text
     assert len(mocked_exporter.namespaces) == 1
     assert "test1" in mocked_exporter.namespaces
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0
 
 
 @pytest.mark.integration
@@ -192,8 +187,7 @@ def test_app_image(caplog: pytest.LogCaptureFixture):
     assert mocked_exporter.date_annotation_name == "io.openshift.build.commit.date"
     assert "date_format='%a %b %d %H:%M:%S %Y %z'" in caplog.text
     assert mocked_exporter.date_format == "%a %b %d %H:%M:%S %Y %z"
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0
 
 
 @pytest.mark.integration
@@ -223,5 +217,4 @@ def test_app_image_with_all_options(caplog: pytest.LogCaptureFixture):
     assert mocked_exporter.date_annotation_name == "custom date annotation"
     assert "date_format='custom format'" in caplog.text
     assert mocked_exporter.date_format == "custom format"
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0

--- a/exporters/tests/test_failure_exporter_app.py
+++ b/exporters/tests/test_failure_exporter_app.py
@@ -16,6 +16,7 @@
 import os
 
 import pytest
+from jira.exceptions import JIRAError
 
 from failure.app import set_up
 from pelorus.config.loading import MissingConfigDataError
@@ -24,6 +25,8 @@ from tests import MockExporter
 
 PAGER_DUTY_TOKEN = os.environ.get("PAGER_DUTY_TOKEN")
 AZURE_DEVOPS_TOKEN = os.environ.get("AZURE_DEVOPS_TOKEN")
+JIRA_USERNAME = os.environ.get("JIRA_USERNAME")
+JIRA_TOKEN = os.environ.get("JIRA_TOKEN")
 
 mocked_failure_exporter = MockExporter(set_up=set_up)
 
@@ -59,8 +62,9 @@ def test_app_pagerduty_with_required_options(caplog: pytest.LogCaptureFixture):
     )
 
     captured_logs = caplog.record_tuples
-    # 9 informational, 5 resolution, 58 creation
-    assert len(captured_logs) == 72
+    assert "Collected " not in caplog.text
+    # number of informational logs
+    assert len(captured_logs) == 8
     # number of error logs
     assert len([record for record in captured_logs if record[1] == 40]) == 0
 
@@ -104,7 +108,132 @@ def test_app_azure_devops_with_required_options(caplog: pytest.LogCaptureFixture
     )
 
     captured_logs = caplog.record_tuples
-    # 10 informational, 3 resolution, 213 creation
-    assert len(captured_logs) == 226
+    assert "Collected " not in caplog.text
+    # number of informational logs
+    assert len(captured_logs) == 9
     # number of error logs
     assert len([record for record in captured_logs if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_jira_without_required_options(caplog: pytest.LogCaptureFixture):
+    with pytest.raises(MissingConfigDataError):
+        mocked_failure_exporter.run_app({"PROVIDER": "jira"})
+
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 9
+
+
+@pytest.mark.integration
+def test_app_jira_with_wrong_token(caplog: pytest.LogCaptureFixture):
+    with pytest.raises(JIRAError):
+        mocked_failure_exporter.run_app(
+            {
+                "PROVIDER": "jira",
+                "API_USER": "fake_user",
+                "TOKEN": "fake_token",
+                "SERVER": "https://pelorustest.atlassian.net",
+            }
+        )
+
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not JIRA_USERNAME, reason="No Jira username set, run export JIRA_USERNAME=username"
+)
+@pytest.mark.skipif(
+    not JIRA_TOKEN, reason="No Jira token set, run export JIRA_TOKEN=token"
+)
+def test_app_jira_with_required_options(caplog: pytest.LogCaptureFixture):
+    mocked_failure_exporter.run_app(
+        {
+            "PROVIDER": "jira",
+            "API_USER": JIRA_USERNAME,
+            "TOKEN": JIRA_TOKEN,
+            "SERVER": "https://pelorustest.atlassian.net",
+        }
+    )
+
+    captured_logs = caplog.record_tuples
+    assert "Collected " not in caplog.text
+    # number of informational logs
+    assert len(captured_logs) == 11
+    # number of error logs
+    assert len([record for record in captured_logs if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_github_without_required_options(caplog: pytest.LogCaptureFixture):
+    with pytest.raises(FailureProviderAuthenticationError):
+        mocked_failure_exporter.run_app({"PROVIDER": "github"})
+
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+
+
+# TODO add token to repo secrets
+# @pytest.mark.integration
+# def test_app_github_with_required_options(caplog: pytest.LogCaptureFixture):
+#     mocked_failure_exporter.run_app(
+#         {
+#             "PROVIDER": "github",
+#             "API_USER": "user",
+#             "TOKEN": "token",
+#         }
+#     )
+
+#     captured_logs = caplog.record_tuples
+#     assert "Collected " not in caplog.text
+#     # number of informational logs
+#     assert len(captured_logs) == 11
+#     # number of error logs
+#     assert len([record for record in captured_logs if record[1] == 40]) == 0
+
+
+@pytest.mark.integration
+def test_app_servicenow_without_required_options(caplog: pytest.LogCaptureFixture):
+    with pytest.raises(MissingConfigDataError):
+        mocked_failure_exporter.run_app({"PROVIDER": "servicenow"})
+
+    # number of error logs
+    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 7
+
+
+# TODO
+# @pytest.mark.integration
+# def test_app_servicenow_with_wrong_token(caplog: pytest.LogCaptureFixture):
+#     with pytest.raises(FailureProviderAuthenticationError):
+#         mocked_failure_exporter.run_app(
+#             {
+#                 "PROVIDER": "servicenow",
+#                 "API_USER": "fake_user",
+#                 "TOKEN": "fake_token",
+#                 "SERVER": "TODO",
+#             }
+#         )
+
+#     # number of error logs
+#     assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+
+
+# TODO add token to repo secrets
+# @pytest.mark.integration
+# def test_app_servicenow_with_required_options(caplog: pytest.LogCaptureFixture):
+#     mocked_failure_exporter.run_app(
+#         {
+#             "PROVIDER": "servicenow",
+#             "API_USER": "user",
+#             "TOKEN": "token",
+#             "SERVER": "",
+#         }
+#     )
+
+#     captured_logs = caplog.record_tuples
+#     assert "Collected " not in caplog.text
+#     # number of informational logs
+#     assert len(captured_logs) == 11
+#     # number of error logs
+#     assert len([record for record in captured_logs if record[1] == 40]) == 0

--- a/exporters/tests/test_failure_exporter_app.py
+++ b/exporters/tests/test_failure_exporter_app.py
@@ -21,7 +21,7 @@ from jira.exceptions import JIRAError
 from failure.app import set_up
 from pelorus.config.loading import MissingConfigDataError
 from pelorus.errors import FailureProviderAuthenticationError
-from tests import MockExporter
+from tests import MockExporter, get_number_of_error_logs, get_number_of_info_logs
 
 PAGER_DUTY_TOKEN = os.environ.get("PAGER_DUTY_TOKEN")
 AZURE_DEVOPS_TOKEN = os.environ.get("AZURE_DEVOPS_TOKEN")
@@ -38,8 +38,7 @@ def test_app_invalid_provider(provider: str, caplog: pytest.LogCaptureFixture):
         mocked_failure_exporter.run_app({"PROVIDER": provider})
 
     # TODO shouldn't be 1?
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 0
+    assert get_number_of_error_logs(caplog.record_tuples) == 0
 
 
 @pytest.mark.integration
@@ -47,8 +46,7 @@ def test_app_pagerduty_without_required_options(caplog: pytest.LogCaptureFixture
     with pytest.raises(FailureProviderAuthenticationError):
         mocked_failure_exporter.run_app({"PROVIDER": "pagerduty"})
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+    assert get_number_of_error_logs(caplog.record_tuples) == 1
 
 
 @pytest.mark.integration
@@ -63,10 +61,8 @@ def test_app_pagerduty_with_required_options(caplog: pytest.LogCaptureFixture):
 
     captured_logs = caplog.record_tuples
     assert "Collected " not in caplog.text
-    # number of informational logs
-    assert len(captured_logs) == 8
-    # number of error logs
-    assert len([record for record in captured_logs if record[1] == 40]) == 0
+    assert get_number_of_info_logs(captured_logs) == 8
+    assert get_number_of_error_logs(captured_logs) == 0
 
 
 @pytest.mark.integration
@@ -74,8 +70,7 @@ def test_app_azure_devops_without_required_options(caplog: pytest.LogCaptureFixt
     with pytest.raises(MissingConfigDataError):
         mocked_failure_exporter.run_app({"PROVIDER": "azure-devops"})
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 7
+    assert get_number_of_error_logs(caplog.record_tuples) == 7
 
 
 @pytest.mark.integration
@@ -89,8 +84,7 @@ def test_app_azure_devops_with_wrong_token(caplog: pytest.LogCaptureFixture):
             }
         )
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+    assert get_number_of_error_logs(caplog.record_tuples) == 1
 
 
 @pytest.mark.integration
@@ -109,10 +103,8 @@ def test_app_azure_devops_with_required_options(caplog: pytest.LogCaptureFixture
 
     captured_logs = caplog.record_tuples
     assert "Collected " not in caplog.text
-    # number of informational logs
-    assert len(captured_logs) == 9
-    # number of error logs
-    assert len([record for record in captured_logs if record[1] == 40]) == 0
+    assert get_number_of_info_logs(captured_logs) == 9
+    assert get_number_of_error_logs(captured_logs) == 0
 
 
 @pytest.mark.integration
@@ -120,8 +112,7 @@ def test_app_jira_without_required_options(caplog: pytest.LogCaptureFixture):
     with pytest.raises(MissingConfigDataError):
         mocked_failure_exporter.run_app({"PROVIDER": "jira"})
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 9
+    assert get_number_of_error_logs(caplog.record_tuples) == 9
 
 
 @pytest.mark.integration
@@ -136,8 +127,7 @@ def test_app_jira_with_wrong_token(caplog: pytest.LogCaptureFixture):
             }
         )
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+    assert get_number_of_error_logs(caplog.record_tuples) == 1
 
 
 @pytest.mark.integration
@@ -159,10 +149,8 @@ def test_app_jira_with_required_options(caplog: pytest.LogCaptureFixture):
 
     captured_logs = caplog.record_tuples
     assert "Collected " not in caplog.text
-    # number of informational logs
-    assert len(captured_logs) == 11
-    # number of error logs
-    assert len([record for record in captured_logs if record[1] == 40]) == 0
+    assert get_number_of_info_logs(captured_logs) == 11
+    assert get_number_of_error_logs(captured_logs) == 0
 
 
 @pytest.mark.integration
@@ -170,8 +158,7 @@ def test_app_github_without_required_options(caplog: pytest.LogCaptureFixture):
     with pytest.raises(FailureProviderAuthenticationError):
         mocked_failure_exporter.run_app({"PROVIDER": "github"})
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+    assert get_number_of_error_logs(caplog.record_tuples) == 1
 
 
 # TODO add token to repo secrets
@@ -187,10 +174,8 @@ def test_app_github_without_required_options(caplog: pytest.LogCaptureFixture):
 
 #     captured_logs = caplog.record_tuples
 #     assert "Collected " not in caplog.text
-#     # number of informational logs
-#     assert len(captured_logs) == 11
-#     # number of error logs
-#     assert len([record for record in captured_logs if record[1] == 40]) == 0
+#     assert get_number_of_info_logs(captured_logs) == 11
+#     assert get_number_of_error_logs(captured_logs) == 0
 
 
 @pytest.mark.integration
@@ -198,8 +183,7 @@ def test_app_servicenow_without_required_options(caplog: pytest.LogCaptureFixtur
     with pytest.raises(MissingConfigDataError):
         mocked_failure_exporter.run_app({"PROVIDER": "servicenow"})
 
-    # number of error logs
-    assert len([record for record in caplog.record_tuples if record[1] == 40]) == 7
+    assert get_number_of_error_logs(caplog.record_tuples) == 7
 
 
 # TODO
@@ -215,8 +199,7 @@ def test_app_servicenow_without_required_options(caplog: pytest.LogCaptureFixtur
 #             }
 #         )
 
-#     # number of error logs
-#     assert len([record for record in caplog.record_tuples if record[1] == 40]) == 1
+#     assert get_number_of_error_logs(caplog.record_tuples) == 1
 
 
 # TODO add token to repo secrets
@@ -233,7 +216,5 @@ def test_app_servicenow_without_required_options(caplog: pytest.LogCaptureFixtur
 
 #     captured_logs = caplog.record_tuples
 #     assert "Collected " not in caplog.text
-#     # number of informational logs
-#     assert len(captured_logs) == 11
-#     # number of error logs
-#     assert len([record for record in captured_logs if record[1] == 40]) == 0
+#     assert get_number_of_info_logs(captured_logs) == 11
+#     assert get_number_of_error_logs(captured_logs) == 0

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.7-rc.9
+VERSION ?= 0.0.7-rc.10
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -46,8 +46,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.9
-    createdAt: "2023-06-05T11:45:14Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.10
+    createdAt: "2023-06-05T16:36:04Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.7-rc.9
+  name: pelorus-operator.v0.0.7-rc.10
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -208,6 +208,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings
@@ -246,15 +255,6 @@ spec:
           - route.openshift.io
           resources:
           - routes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
           verbs:
           - '*'
         - apiGroups:
@@ -406,7 +406,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.9
+                image: quay.io/pelorus/pelorus-operator:0.0.7-rc.10
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -508,7 +508,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.7-rc.9
+  version: 0.0.7-rc.10
   replaces: pelorus-operator.v0.0.6
   skips:
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.7-rc.9
+  newTag: 0.0.7-rc.10

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.9
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.7-rc.10
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,15 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
+- verbs:
+  - "*"
+  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "rolebindings"
@@ -93,14 +102,5 @@ rules:
   - "route.openshift.io"
   resources:
   - "routes"
-- verbs:
-  - "*"
-  apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.9
-digest: sha256:332b336da48d6b79fb023eb0c369dfa669f3250ecaaaa3bdf9db74bb53e0af3f
-generated: "2023-06-05T13:45:09.852506665+02:00"
+  version: 2.0.10-rc.10
+digest: sha256:115b22617b409c7440e5c8ced3d7b31b6623bf7da421538c3af5271b566d3ade
+generated: "2023-06-05T13:36:00.296376463-03:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.10-rc.9
+  version: 2.0.10-rc.10
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.10-rc.9
+version: 2.0.10-rc.10

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.10-rc.9
+version: 2.0.10-rc.10

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.10" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.9" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.10-rc.10" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

resolves #1006

## Description

Restricts the amount of logs when user sets it to INFO (the default).

## Testing Instructions

Check the logs of Committime, Deploytime, failure and webhook exporters with log level set to INFO.
