### PR TITLE
Fix various dev tool install issues, make shellcheck a required lint

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11']
 
     steps:
       - name: Checkout

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,10 +14,6 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.11']
 
     steps:
       - name: Checkout
@@ -26,7 +22,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: |
             **/requirements*.txt

--- a/Makefile
+++ b/Makefile
@@ -220,15 +220,17 @@ chart-lint-optional:
 	$(warning chart test (ct) not installed, skipping)
 endif
 
-shellcheck: $(PELORUS_VENV) $(PELORUS_VENV)/bin/shellcheck
-	. ${PELORUS_VENV}/bin/activate && \
-	if [[ -z shellcheck ]]; then echo "Shellcheck is not installed" >&2; false; fi && \
-	echo "🐚 📋 Linting shell scripts with shellcheck" && \
-	shellcheck $(shell find . -name '*.sh' -type f | grep -v 'venv/\|git/\|.pytest_cache/\|htmlcov/\|_test/test_helper/\|_test/bats\|_test/conftest')
 
 ifneq (, $(SHELLCHECK))
+shellcheck: $(PELORUS_VENV) $(PELORUS_VENV)/bin/shellcheck
+	. ${PELORUS_VENV}/bin/activate && \
+	echo "🐚 📋 Linting shell scripts with shellcheck" && \
+	shellcheck $(shell find . -name '*.sh' -type f | grep -v 'venv/\|git/\|.pytest_cache/\|htmlcov/\|_test/test_helper/\|_test/bats\|_test/conftest')
 shellcheck-optional: shellcheck
 else
+shellcheck:
+	echo "Shellcheck is not installed" >&2
+	@false
 shellcheck-optional:
 	$(warning 🐚 ⏭ Shellcheck not found, skipping)
 endif

--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,9 @@ isort-check: $(PELORUS_VENV)
 
 # Linting
 
-.PHONY: lint python-lint pylava chart-lint chart-lint-optional shellcheck shellcheck-optional typecheck
+.PHONY: lint python-lint pylava chart-lint chart-lint-optional shellcheck typecheck
 ## lint: lint python code, shell scripts, and helm charts
-lint: python-lint chart-lint-optional shellcheck-optional
+lint: python-lint chart-lint-optional shellcheck
 
 ## python-lint: lint python files
 python-lint: $(PELORUS_VENV)
@@ -220,20 +220,11 @@ chart-lint-optional:
 	$(warning chart test (ct) not installed, skipping)
 endif
 
-
-ifneq (, $(SHELLCHECK))
 shellcheck: $(PELORUS_VENV) $(PELORUS_VENV)/bin/shellcheck
+	@echo "🐚 📋 Linting shell scripts with shellcheck"
 	. ${PELORUS_VENV}/bin/activate && \
-	echo "🐚 📋 Linting shell scripts with shellcheck" && \
 	shellcheck $(shell find . -name '*.sh' -type f | grep -v 'venv/\|git/\|.pytest_cache/\|htmlcov/\|_test/test_helper/\|_test/bats\|_test/conftest')
-shellcheck-optional: shellcheck
-else
-shellcheck:
-	echo "Shellcheck is not installed" >&2
-	@false
-shellcheck-optional:
-	$(warning 🐚 ⏭ Shellcheck not found, skipping)
-endif
+
 
 ## doc-check: Check if there is any problem with the project documentation generation
 doc-check: $(PELORUS_VENV)

--- a/scripts/get_tool_dl_url.py
+++ b/scripts/get_tool_dl_url.py
@@ -73,7 +73,7 @@ class Nooba:
     "Nooba's URL pattern."
 
     repo = "noobaa/noobaa-operator"
-    arch = "mac" if OS == "Darwin" else "linux"
+    arch = OS.lower()
     pattern = re.compile(f"https://(.*)-{arch}-(.*)[0-9]")
 
     @classmethod

--- a/scripts/get_tool_dl_url.py
+++ b/scripts/get_tool_dl_url.py
@@ -199,6 +199,7 @@ parser.add_argument(
     help=f"The executable to retrieve the URL for.\nSupported: {', '.join(CLI_NAMES)}",
     choices=CLI_NAMES,
 )
+parser.add_argument("-v", "--verbose", action="store_true", default=False)
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -218,5 +219,9 @@ if __name__ == "__main__":
         if tool.matcher(asset.url):
             print(asset.url)
             sys.exit()
+        elif args.verbose:
+            sys.stderr.write(
+                f"{asset.name} at {asset.url} does not match pattern for {software}\n"
+            )
 
     sys.exit(f"No matching download URL found for {software} on {OS} {ARCH}")

--- a/scripts/get_tool_dl_url.py
+++ b/scripts/get_tool_dl_url.py
@@ -98,6 +98,28 @@ class OperatorSdk:
         return cls.pattern.search(url) is not None
 
 
+class Shellcheck:
+    "Shellcheck's URL pattern"
+    repo = "koalaman/shellcheck"
+
+    os = OS.lower()
+
+    if ARCH in X86_64_ARCH_NAMES or OS == "Darwin":
+        # currently no native arm downloads for darwin
+        # so we just use x86 and rosetta it
+        arch = "x86_64"
+    elif ARCH == "arm64":
+        arch = "aarch64"
+    else:
+        sys.exit(f"Unsupported OS {OS}")
+
+    pattern = f"{os}.{arch}.tar.xz"
+
+    @classmethod
+    def url_matches(cls, url: str) -> bool:
+        return cls.pattern in url
+
+
 class Tool(enum.Enum):
     "Maps the dev tools we want to their repos and respective URL matchers."
 
@@ -109,7 +131,8 @@ class Tool(enum.Enum):
     ct = "helm/chart-testing", StandardTool.url_matches
     conftest = "open-policy-agent/conftest", StandardTool.url_matches
     promtool = "prometheus/prometheus", StandardTool.url_matches
-    shellcheck = "koalaman/shellcheck", StandardTool.url_matches
+
+    shellcheck = Shellcheck.repo, Shellcheck.url_matches
 
     noobaa = Nooba.repo, Nooba.url_matches
 

--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -267,8 +267,8 @@ if should_cli_be_installed "noobaa" "${cli_tools_arr[@]}" && \
       echo "$NOOBAA_CLIENT_URL"
       download_file_from_url "${NOOBAA_CLIENT_URL}" "${DWN_DIR}"
       NOOBAA_CLIENT_PATH="${DWN_DIR}"/$(basename "${NOOBAA_CLIENT_URL}")
-      mv "${NOOBAA_CLIENT_PATH}" "${VENV}/bin/noobaa"
-      chmod +x "${VENV}/bin/noobaa"
+      extract_file_to_dir "${NOOBAA_CLIENT_PATH}" "${VENV}/bin/"
+      mv "${VENV}/bin/noobaa-operator" "${VENV}/bin/noobaa"
 fi
 
 if should_cli_be_installed "operator-sdk" "${cli_tools_arr[@]}" && \

--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -111,7 +111,7 @@ function should_cli_be_installed(){
 # Function to safely remove temporary files and temporary download dir
 # Argument is optional exit value to propagate it after cleanup
 function cleanup_and_exit() {
-    local exit_val=$1
+    local exit_val=${1:-1}
     if [ -z "${DWN_DIR}" ]; then
         echo "cleanup_and_exit(): Temp download dir not provided !" >&2
     else
@@ -120,14 +120,12 @@ function cleanup_and_exit() {
           PELORUS_TMP_DIR=$(basename "${DWN_DIR}")
           if [[ "${PELORUS_TMP_DIR}" =~ "${TMP_DIR_PREFIX}"* ]]; then
               echo "Cleaning up temporary files"
-              eval rm -f "${DWN_DIR}/*"
-              rmdir "${DWN_DIR}"
+              rm -rf -- "${DWN_DIR}"
           fi
       fi
     fi
-    # Propagate exit value if was provided
-    [ -n "${exit_val}" ] && exit "$exit_val"
-    exit 0
+    trap - EXIT
+    exit "$exit_val"
 }
 
 function print_help() {
@@ -300,3 +298,5 @@ if should_cli_be_installed "poetry" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${DEFAULT_VENV}/bin/poetry")" ]; then
         curl -sSL https://install.python-poetry.org | POETRY_HOME="$DEFAULT_VENV" python3 -
 fi
+
+exit 0

--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -299,4 +299,4 @@ if should_cli_be_installed "poetry" "${cli_tools_arr[@]}" && \
         curl -sSL https://install.python-poetry.org | POETRY_HOME="$DEFAULT_VENV" python3 -
 fi
 
-exit 0
+cleanup_and_exit 0


### PR DESCRIPTION
Fixes #518

Fixes non-reported(?) issues with installing noobaa and shellcheck on ARM macs

It also looks like our shellcheck github action has been broken for a _while_. This PR:

- fixes the shellcheck makefile target
- simplifies that target
- makes shellcheck linting mandatory (I can separate this into another PR if you wish.)
- makes the github action only run on one version of python (it's irrelevant to python)


## Testing Instructions

### Positive Test

1. Remove all non-python executables from your venv's `bin` dir (or just remove the whole venv)
2. `make cli_dev_tools`
3. Verify that all expected cli tools are present, including shellcheck and noobaa  
   (this only matters if you're on an ARM mac)

### Negative Test

1. Modify one of the tools' repo names / URLs in `get_tool_dl_url.py` so that the url check fails
2. Verify that the `install_dev_tools` script exits with a non-zero exit status