### PR TITLE
fix: federate_openshift_monitoring breaks with multiple metrics filters

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.11
+version: 2.0.12-rc.1

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.11
-digest: sha256:9ed2f72cd5c183c693703f3ab85459f67c82c5c5b26e5d58605bb40de1828295
-generated: "2023-08-17T10:54:59.688723991-03:00"
+  version: 2.0.12-rc.1
+digest: sha256:138eedeac8258862c9a4d47987e17cd46f6a77ae620f8151eb7f3e783fb6a702
+generated: "2023-08-28T13:16:06.613566112-04:00"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.11
+version: 2.0.12-rc.1
 
 dependencies:
   - name: exporters
-    version: 2.0.11
+    version: 2.0.12-rc.1
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.11
+version: 2.0.12-rc.1

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.11" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12-rc.1" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.11" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12-rc.1" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -8,7 +8,9 @@
   params:
     'match[]':
     {{- if .metrics_filter }}
-      {{ .metrics_filter | toYaml }}
+      {{- range .metrics_filter }}
+      - '{{ . }}'
+      {{- end }}
     {{- else }}
       - '{job="kube-state-metrics"}'
       - '{job="openshift-state-metrics"}'

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.8
+VERSION ?= 0.0.9-rc.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.8
-    createdAt: "2023-08-17T13:57:14Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.9-rc.1
+    createdAt: "2023-08-28T17:16:10Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -58,7 +58,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.8
+  name: pelorus-operator.v0.0.9-rc.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -409,7 +409,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.8
+                image: quay.io/pelorus/pelorus-operator:0.0.9-rc.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -511,9 +511,10 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.8
-  replaces: pelorus-operator.v0.0.7
+  version: 0.0.9-rc.1
+  replaces: pelorus-operator.v0.0.8
   skips:
+    - pelorus-operator.v0.0.8
     - pelorus-operator.v0.0.7
     - pelorus-operator.v0.0.6
     - pelorus-operator.v0.0.5

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.8
+  newTag: 0.0.9-rc.1

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.8
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.9-rc.1
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.11
-digest: sha256:9ed2f72cd5c183c693703f3ab85459f67c82c5c5b26e5d58605bb40de1828295
-generated: "2023-08-17T10:55:00.128022534-03:00"
+  version: 2.0.12-rc.1
+digest: sha256:138eedeac8258862c9a4d47987e17cd46f6a77ae620f8151eb7f3e783fb6a702
+generated: "2023-08-28T13:16:07.017093906-04:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.11
+  version: 2.0.12-rc.1
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.11
+version: 2.0.12-rc.1

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.11
+version: 2.0.12-rc.1

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.11" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12-rc.1" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.11" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12-rc.1" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -8,7 +8,9 @@
   params:
     'match[]':
     {{- if .metrics_filter }}
-      {{ .metrics_filter | toYaml }}
+      {{- range .metrics_filter }}
+      - '{{ . }}'
+      {{- end }}
     {{- else }}
       - '{job="kube-state-metrics"}'
       - '{job="openshift-state-metrics"}'


### PR DESCRIPTION
* [General PR](?expand=1&template=general_template.md)

When passing a list to `federate_openshift_monitoring.metrics_filter` that contains more than one node, every node after the first gets rendered in the helm chart, is missing indentation.

Example:

Given the following values file:

```
federate_openshift_monitoring:
  enabled: true
  metrics_filter:
  - "kube_pod_container_info{}"
  - "kube_pod_status_phase{}"
exporters:
  global: {}
  instances: []
```

You get the following output:
```
helm template pelorus ./charts/pelorus/ --values examples/ocp-fed-values.yaml --debug | yq '. | select(.kind == "Secret" and .metadata.name == "pelorus-prometheus-additional-scrape-configs")' | jq -r '.data["prometheus-additional.yml"]' | base64 -d

install.go:159: [debug] Original chart version: ""
install.go:176: [debug] CHART PATH: /home/esauer/src/pelorus/charts/pelorus


- job_name: 'federate'
  scrape_interval: 15s
  honor_labels: true
  metrics_path: '/federate'
  params:
    'match[]':
      - 'kube_pod_container_info{}'
- 'kube_pod_status_phase{}' <-- this is broken
  static_configs:
    - targets:
      # This is a statically named endpoint that should be the same in all clusters
      - 'prometheus-k8s.openshift-monitoring.svc:9091'
  scheme: https
  tls_config:
    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
  authorization:
    credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
```

This PR fixes the formatting error by iterating through the list of filters rather than treating it like a block of YAML.