### PR TITLE
Update OCP check script and upstream support with the prow changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,8 @@
 
 Prow CI Periodic E2E Tests:
 
-- OpenShift version 4.10 [![4.10 scenario 1 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.10-e2e-openshift-test-scenario-1-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.10-e2e-openshift-test-scenario-1-periodic)
-[![4.10 scenario 2 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.10-e2e-openshift-test-scenario-2-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.10-e2e-openshift-test-scenario-2-periodic)
-
-- OpenShift version 4.11 [![4.11 scenario 1 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.11-e2e-openshift-test-scenario-1-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.11-e2e-openshift-test-scenario-1-periodic)
-[![4.11 scenario 2 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.11-e2e-openshift-test-scenario-2-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.11-e2e-openshift-test-scenario-2-periodic)
-
-- OpenShift version 4.12 [![4.12 scenario 1 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.12-e2e-openshift-test-scenario-1-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.12-e2e-openshift-test-scenario-1-periodic)
-[![4.12 scenario 2 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.12-e2e-openshift-test-scenario-2-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.12-e2e-openshift-test-scenario-2-periodic)
-
 - OpenShift version 4.13 [![4.13 scenario 1 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.13-e2e-openshift-test-scenario-1-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.13-e2e-openshift-test-scenario-1-periodic)
-[![4.13 scenario 2 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.13-e2e-openshift-test-scenario-2-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.13-e2e-openshift-test-scenario-2-periodic)
+
 
 Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
 

--- a/docs/UpstreamSupport.md
+++ b/docs/UpstreamSupport.md
@@ -1,8 +1,8 @@
 # Pelorus Upstream Support Statement
 
-The Pelorus engineering team will provide **best-effort** level support for it on the currently latest and the latest 3 previous released stable minor versions of OpenShift version 4.
+The Pelorus engineering team will provide **best-effort** level support for it on the currently latest released stable minor version of the OpenShift 4.
 
-> **NOTE:** Pelorus is currently automated tested against versions **4.10**, **4.11**, **4.12** and **4.13** of OpenShift.
+> **NOTE:** Pelorus is currently automated tested against version **4.13** of OpenShift.
 
 * To file a bug, please create a [Bug issue](https://github.com/dora-metrics/pelorus/issues/new?assignees=&labels=kind%2Fbug%2Cneeds-triage&template=bug.yml)
 

--- a/scripts/check_openshift_version.py
+++ b/scripts/check_openshift_version.py
@@ -26,11 +26,12 @@ OPENSHIFT_REPO = "openshift/release"
 OPENSHIFT_BRANCH = "master"
 RAW_URL = f"https://raw.githubusercontent.com/{OPENSHIFT_REPO}/{OPENSHIFT_BRANCH}"
 
+OCP_VERSIONS_URL = "https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/graph"
+NO_LAST_OCP_VERSIONS = 1
+
 
 def get_supported_versions() -> List[str]:
-    with request.urlopen(
-        "https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/graph"
-    ) as response:
+    with request.urlopen(OCP_VERSIONS_URL) as response:
         versions: List[Dict[str, str]] = list(json.load(response)["nodes"])
     stable_versions = [
         version["version"]
@@ -44,7 +45,10 @@ def get_supported_versions() -> List[str]:
     latest_minor_versions = list(minor_versions)
     latest_minor_versions.sort(reverse=True)
 
-    return [f"{version.major}.{version.minor}" for version in latest_minor_versions[:4]]
+    return [
+        f"{version.major}.{version.minor}"
+        for version in latest_minor_versions[:NO_LAST_OCP_VERSIONS]
+    ]
 
 
 def check_version_in_openshift_repo(version: str, file_name: str) -> None:
@@ -86,7 +90,9 @@ def check_versions(versions: List[str]) -> None:
 
 def main() -> None:
     supported_versions = get_supported_versions()
-    logging.info(f"Latest minor OpenShift releases: {', '.join(supported_versions)}")
+    logging.info(
+        f"Last '{NO_LAST_OCP_VERSIONS}' minor OpenShift release(s): {', '.join(supported_versions)}"
+    )
     check_versions(supported_versions)
 
     log_cache: dict = logging.getLogger()._cache


### PR DESCRIPTION
The PROW CI jobs were updated to use only latest OCP release for their runs. The documentation and the check openshift version script needs to be changed as well.

PROW PR: https://github.com/openshift/release/pull/44348
