### PR TITLE
Fixed issue with projects field in the failuretime exporter using Azure DevOps

### DIFF
--- a/exporters/failure/collector_azure_devops.py
+++ b/exporters/failure/collector_azure_devops.py
@@ -27,7 +27,7 @@ from msrest.authentication import BasicAuthentication
 
 from failure.collector_base import AbstractFailureCollector, TrackerIssue
 from pelorus.config import env_var_names, env_vars
-from pelorus.config.converters import comma_separated, comma_or_whitespace_separated, pass_through
+from pelorus.config.converters import comma_or_whitespace_separated, pass_through
 from pelorus.config.log import REDACT, log
 from pelorus.errors import FailureProviderAuthenticationError
 from pelorus.timeutil import parse_assuming_utc_with_fallback, second_precision
@@ -54,7 +54,7 @@ class AzureDevOpsFailureCollector(AbstractFailureCollector):
     )
 
     projects: set[str] = field(
-        factory=set, converter=comma_separated(set)
+        factory=set, converter=comma_or_whitespace_separated(set)
     )
 
     work_item_type: set[str] = field(

--- a/exporters/failure/collector_azure_devops.py
+++ b/exporters/failure/collector_azure_devops.py
@@ -27,7 +27,7 @@ from msrest.authentication import BasicAuthentication
 
 from failure.collector_base import AbstractFailureCollector, TrackerIssue
 from pelorus.config import env_var_names, env_vars
-from pelorus.config.converters import comma_or_whitespace_separated, pass_through
+from pelorus.config.converters import comma_separated, comma_or_whitespace_separated, pass_through
 from pelorus.config.log import REDACT, log
 from pelorus.errors import FailureProviderAuthenticationError
 from pelorus.timeutil import parse_assuming_utc_with_fallback, second_precision
@@ -54,7 +54,7 @@ class AzureDevOpsFailureCollector(AbstractFailureCollector):
     )
 
     projects: set[str] = field(
-        factory=set, converter=comma_or_whitespace_separated(set)
+        factory=set, converter=comma_separated(set)
     )
 
     work_item_type: set[str] = field(


### PR DESCRIPTION
Problem: If an Azure DevOps server has a project name with a space in it ("Test Project" for example), the _projects_ variable in _exporters/failure/collector_azure_devops.py_ separates the project into two, causing it not to pick up the project. In the documentation the environment variable for projects asks for a "comma separated list of strings" [here](https://pelorus.readthedocs.io/en/v2.0.11/GettingStarted/configuration/ExporterFailure/#projects), yet a space causes it to be separated as well. 

Example: The project "Test Project" would be separated into ["Test", "Project"], meaning "Test Project" would never be picked up by the failuretime exporter. Whereas we would want it to be separated to ["Test Project"].

Solution: Use the provided comma_separated function to properly separate the projects provided to the failuretime exporter.