### PR TITLE
Update the helm-operator image to v1.34 which has fewer vulnerabilities

### DIFF
--- a/pelorus-operator/Dockerfile
+++ b/pelorus-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.28.1
+FROM quay.io/operator-framework/helm-operator:v1.34
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

<!-- Use this if merging should NOT auto-close an issue, one issue per line -->
related to #1128 

## Description

Update the helm-operator image to v1.34 which has fewer vulnerabilities

## Testing Instructions

Once images are pushed to quay, let the Claire scans run and confirm there are fewer vulnerabilities
