### PR TITLE
Fix scrape config secret indentation so that multiple configs work to…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -1,51 +1,211 @@
-![Pelorus](docs/img/Logo-Pelorus-A-Standard-RGB_smaller.png)
+# Chart Testing
 
-[![Python Linting](https://github.com/dora-metrics/pelorus/actions/workflows/python-linting.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
-[![Unit tests](https://github.com/dora-metrics/pelorus/actions/workflows/unittests.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
-[![Conftest](https://github.com/dora-metrics/pelorus/actions/workflows/conftest.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
-[![Chart Lint](https://github.com/dora-metrics/pelorus/actions/workflows/chart-lint.yml/badge.svg)](https://github.com/dora-metrics/pelorus/actions)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Go Report Card](https://goreportcard.com/badge/github.com/helm/chart-testing)](https://goreportcard.com/report/github.com/helm/chart-testing)
+![ci](https://github.com/helm/chart-testing/workflows/ci/badge.svg)
 
-Prow CI Periodic E2E Tests:
+`ct` is the the tool for testing Helm charts.
+It is meant to be used for linting and testing pull requests.
+It automatically detects charts changed against the target branch.
 
-- OpenShift version 4.13 [![4.13 scenario 1 builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-dora-metrics-pelorus-master-4.13-e2e-openshift-test-scenario-1-periodic)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-dora-metrics-pelorus-master-4.13-e2e-openshift-test-scenario-1-periodic)
+## Installation
+
+### Prerequisites
+
+It is recommended to use the provided Docker image which can be [found on Quay](https://quay.io/helmpack/chart-testing/).
+It comes with all necessary tools installed.
+
+* [Helm](http://helm.sh)
+* [Git](https://git-scm.com) (2.17.0 or later)
+* [Yamllint](https://github.com/adrienverge/yamllint)
+* [Yamale](https://github.com/23andMe/Yamale)
+* [Kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)
+
+### Binary Distribution
+
+Download the release distribution for your OS from the Releases page:
+
+https://github.com/helm/chart-testing/releases
+
+Unpack the `ct` binary, add it to your PATH, and you are good to go!
+
+### Docker Image
+
+A Docker image is available at `quay.io/helmpack/chart-testing` with list of
+available tags [here](https://quay.io/repository/helmpack/chart-testing?tab=tags).
+
+### Homebrew
+
+```console
+$ brew install chart-testing
+```
+
+## Usage
+
+See documentation for individual commands:
+
+* [ct](doc/ct.md)
+* [ct install](doc/ct_install.md)
+* [ct lint](doc/ct_lint.md)
+* [ct lint-and-install](doc/ct_lint-and-install.md)
+* [ct list-changed](doc/ct_list-changed.md)
+* [ct version](doc/ct_version.md)
+
+For a more extensive how-to guide, please see:
+
+* [charts-repo-actions-demo](https://github.com/helm/charts-repo-actions-demo)
+
+## Configuration
+
+`ct` is a command-line application.
+All command-line flags can also be set via environment variables or config file.
+Environment variables must be prefixed with `CT_`.
+Underscores must be used instead of hyphens.
+
+CLI flags, environment variables, and a config file can be mixed.
+The following order of precedence applies:
+
+1. CLI flags
+1. Environment variables
+1. Config file
+
+Note that linting requires config file for [yamllint](https://github.com/adrienverge/yamllint) and [yamale](https://github.com/23andMe/Yamale).
+If not specified, these files are search in the current directory, the `.ct` directory in current directory, `$HOME/.ct`, and `/etc/ct`, in that order.
+Samples are provided in the [etc](etc) folder.
+
+### Examples
+
+The following example show various way of configuring the same thing:
+
+#### CLI
+
+#### Remote repo
+
+With remote repo:
+
+    ct install --remote upstream --chart-dirs stable,incubator --build-id pr-42
+
+#### Local repo
+
+If you have a chart in current directory and ct installed on the host then you can run:
+
+    ct install --chart-dirs . --charts .
+
+With docker it works with:
+
+    docker run -it --network host --workdir=/data --volume ~/.kube/config:/root/.kube/config:ro --volume $(pwd):/data quay.io/helmpack/chart-testing:v3.7.1 ct install --chart-dirs . --charts .
+
+Notice that `workdir` param is important and must be the same as volume mounted.
 
 
-Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
+#### Environment Variables
 
-- Software Delivery Performance
-- Product Quality and Sustainability
-- Customer experience
+    export CT_REMOTE=upstream
+    export CT_CHART_DIRS=stable,incubator
+    export CT_BUILD_ID
 
-For more background on the project you can read [@trevorquinn](https://github.com/trevorquinn)'s blog post on [Metrics Driven Transformation](https://www.openshift.com/blog/exploring-a-metrics-driven-approach-to-transformation).
+    ct install
 
-## Software Delivery Performance as an outcome
+#### Config File
 
-Currently, Pelorus functionality can capture proven metrics that measure Software Delivery Performance -- a significant outcome that IT organizations aim to deliver.
+`config.yaml`:
 
-Pelorus is a Grafana dashboard that can easily be deployed to an OpenShift cluster, and provides an organizational-level view of the [four critical measures of software delivery performance](https://blog.openshift.com/exploring-a-metrics-driven-approach-to-transformation/).
+```yaml
+remote: upstream
+chart-dirs:
+  - stable
+  - incubator
+build-id: pr-42
+```
 
-![Software Delivery Metrics Dashboard](docs/img/sdp-dashboard.png)
+#### Config Usage
 
-A short video describing each of these metrics is available [here](https://www.youtube.com/watch?v=7-iB_KhUaQg).
+    ct install --config config.yaml
 
-## Documentation
 
-Pelorus documentation is available at [pelorus.readthedocs.io](https://pelorus.readthedocs.io/).
+`ct` supports any format [Viper](https://github.com/spf13/viper) can read, i. e. JSON, TOML, YAML, HCL, and Java properties files.
 
-## Contributing to Pelorus
+Notice that if no config file is specified, then `ct.yaml` (or any of the supported formats) is loaded from the current directory, `$HOME/.ct`, or `/etc/ct`, in that order, if found.
 
-If you are interested in contributing to the Pelorus project, please review our Contribution guide which can be found in the [contribution guide](./CONTRIBUTING.md)
 
-## Statement of Support
+#### Using private chart repositories
 
-Our support policy can be found in the [Upstream Support statement](docs/UpstreamSupport.md)
+When adding chart-repos you can specify additional arguments for the `helm repo add` command using `helm-repo-extra-args` on a per-repo basis.
+You can also specify OCI registries which will be added using the `helm registry login` command, they also support the `helm-repo-extra-args` for authentication.
+This could for example be used to authenticate a private chart repository.
 
-## Code of Conduct
-Refer to dora-metrics's Code of Conduct [here](./CODE_OF_CONDUCT.md).
+`config.yaml`:
 
-## License
+```yaml
+chart-repos:
+  - incubator=https://incubator.io
+  - basic-auth=https://private.com
+  - ssl-repo=https://self-signed.ca
+  - oci-registry=oci://nice-oci-registry.pt
+helm-repo-extra-args:
+  - ssl-repo=--ca-file ./my-ca.crt
+```
 
-This repository is licensed under the terms of [Apache-2.0 License](LICENSE).
+    ct install --config config.yaml --helm-repo-extra-args "basic-auth=--username user --password secret"
+
+## Building from Source
+
+`ct` is built using Go 1.13 or higher.
+
+`build.sh` is used to build and release the tool.
+It uses [Goreleaser](https://goreleaser.com/) under the covers.
+
+Note: on MacOS you will need `GNU Coreutils readlink`.
+You can install it with:
+
+```console
+brew install coreutils
+```
+
+Then add `gnubin` to your `$PATH`, with:
+
+```console
+echo 'export PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"' >> ~/.bash_profile
+bash --login
+```
+
+To use the build script:
+
+```console
+$ ./build.sh -h
+Usage: build.sh <options>
+
+Build ct using Goreleaser.
+
+    -h, --help      Display help
+    -d, --debug     Display verbose output and run Goreleaser with --debug
+    -r, --release   Create a release using Goreleaser. This includes the creation
+                    of a GitHub release and building and pushing the Docker image.
+                    If this flag is not specified, Goreleaser is run with --snapshot
+```
+
+## Releasing
+
+### Prepare Release
+
+Before a release is created, versions have to be updated in the examples.
+A pull request needs to be created for this, which should be merged right before the release is cut.
+Here's a previous one for reference: https://github.com/helm/chart-testing/pull/89
+
+### Create Release
+
+The release workflow is [dispatched from github actions](https://github.com/helm/chart-testing/actions)
+Versions must start with a lower-case `v`, e. g. `v3.7.1`.
+
+## Supported versions
+
+The previous MAJOR version will be supported for three months after each new MAJOR release.
+
+Within this support window, pull requests for the previous MAJOR version should be made against the previous release branch.
+For example, if the current MAJOR version is `v2`, the pull request base branch should be `release-v1`.
+
+## Upgrading
+
+When upgrading from `< v2.0.0` you will also need to change the usage in your scripts.
+This is because, while the [v2.0.0](https://github.com/helm/chart-testing/releases/tag/v2.0.0) release has parity with `v1`, it was refactored from a bash library to Go so there are minor syntax differences.
+Compare [v1 usage](https://github.com/helm/chart-testing/tree/release-v1#usage) with this (`v2`) version's README [usage](#usage) section above.

--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.12
+version: 2.0.13-rc.1

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.12
-digest: sha256:5c8bd23146040c7cf0cf6773a7683b76d7e1fe13ebb3d72aa2061ea9c5924159
-generated: "2024-05-27T17:03:56.379849633-03:00"
+  version: 2.0.13-rc.1
+digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
+generated: "2024-07-11T19:08:27.806745358Z"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.12
+version: 2.0.13-rc.1
 
 dependencies:
   - name: exporters
-    version: 2.0.12
+    version: 2.0.13-rc.1
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.12
+version: 2.0.13-rc.1

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -27,35 +27,35 @@
   {{- end }}
   {{- end }}
   {{- range .Values.federated_prometheus_hosts }}
-  - job_name: "federated-prometheus-{{ .id }}"
-    scrape_interval: 15s
-    honor_labels: true
-    metrics_path: '/federate'
-    params:
-      'match[]':
-        - '{job="openshift-state-metrics"}'
-    scheme: "https"
-    basic_auth:
-      username: 'internal'
-      password: "{{ .password }}"
-    tls_config:
-      insecure_skip_verify: true
-    static_configs:
-      - targets:
-          - "{{ .hostname }}"
-        labels:
-          federated_job: "federated-prometheus-{{ .id }}"
+- job_name: "federated-prometheus-{{ .id }}"
+  scrape_interval: 15s
+  honor_labels: true
+  metrics_path: '/federate'
+  params:
+    'match[]':
+      - '{job="openshift-state-metrics"}'
+  scheme: "https"
+  basic_auth:
+    username: 'internal'
+    password: "{{ .password }}"
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+    - targets:
+        - "{{ .hostname }}"
+      labels:
+        federated_job: "federated-prometheus-{{ .id }}"
   {{- end }}
   {{- range .Values.external_prometheus_hosts }}
-  - job_name: "external-prometheus-{{ .id }}"
-    scrape_interval: 15s
-    tls_config:
-      insecure_skip_verify: true
-    static_configs:
-      - targets:
-          - "{{ .hostname }}"
-        labels:
-          external_job: "external-prometheus-{{ .id }}"
+- job_name: "external-prometheus-{{ .id }}"
+  scrape_interval: 15s
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+    - targets:
+        - "{{ .hostname }}"
+      labels:
+        external_job: "external-prometheus-{{ .id }}"
   {{- end }}
 {{- end }}
 {{- if or .Values.federated_prometheus_hosts .Values.external_prometheus_hosts .Values.federate_openshift_monitoring.enabled }}

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.9
+VERSION ?= 0.0.10-rc.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.9
-    createdAt: "2024-05-27T20:04:01Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
+    createdAt: "2024-07-11T19:08:34Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -58,7 +58,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.9
+  name: pelorus-operator.v0.0.10-rc.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -211,6 +211,26 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheuses
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
           - ""
           resources:
           - configmaps
@@ -238,26 +258,6 @@ spec:
           - grafanadashboards
           - grafanadatasources
           - grafanas
-          verbs:
-          - '*'
-        - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - prometheuses
-          - prometheusrules
-          - servicemonitors
-          verbs:
-          - '*'
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
           verbs:
           - '*'
         - apiGroups:
@@ -393,7 +393,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.9
+                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -495,9 +495,10 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.9
-  replaces: pelorus-operator.v0.0.8
+  version: 0.0.10-rc.1
+  replaces: pelorus-operator.v0.0.9
   skips:
+    - pelorus-operator.v0.0.9
     - pelorus-operator.v0.0.8
     - pelorus-operator.v0.0.7
     - pelorus-operator.v0.0.6

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.9
+  newTag: 0.0.10-rc.1

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.9
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,26 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - "image.openshift.io"
+  resources:
+  - "imagestreams"
+- verbs:
+  - "*"
+  apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - "prometheuses"
+  - "prometheusrules"
+  - "servicemonitors"
+- verbs:
+  - "*"
+  apiGroups:
+  - "route.openshift.io"
+  resources:
+  - "routes"
+- verbs:
+  - "*"
+  apiGroups:
   - ""
   resources:
   - "configmaps"
@@ -82,25 +102,5 @@ rules:
   - "grafanadashboards"
   - "grafanadatasources"
   - "grafanas"
-- verbs:
-  - "*"
-  apiGroups:
-  - "image.openshift.io"
-  resources:
-  - "imagestreams"
-- verbs:
-  - "*"
-  apiGroups:
-  - "monitoring.coreos.com"
-  resources:
-  - "prometheuses"
-  - "prometheusrules"
-  - "servicemonitors"
-- verbs:
-  - "*"
-  apiGroups:
-  - "route.openshift.io"
-  resources:
-  - "routes"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.12
-digest: sha256:5c8bd23146040c7cf0cf6773a7683b76d7e1fe13ebb3d72aa2061ea9c5924159
-generated: "2024-05-27T17:03:56.894029532-03:00"
+  version: 2.0.13-rc.1
+digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
+generated: "2024-07-11T19:08:28.036277921Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.12
+  version: 2.0.13-rc.1
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.12
+version: 2.0.13-rc.1

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.12
+version: 2.0.13-rc.1

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.12" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -27,35 +27,35 @@
   {{- end }}
   {{- end }}
   {{- range .Values.federated_prometheus_hosts }}
-  - job_name: "federated-prometheus-{{ .id }}"
-    scrape_interval: 15s
-    honor_labels: true
-    metrics_path: '/federate'
-    params:
-      'match[]':
-        - '{job="openshift-state-metrics"}'
-    scheme: "https"
-    basic_auth:
-      username: 'internal'
-      password: "{{ .password }}"
-    tls_config:
-      insecure_skip_verify: true
-    static_configs:
-      - targets:
-          - "{{ .hostname }}"
-        labels:
-          federated_job: "federated-prometheus-{{ .id }}"
+- job_name: "federated-prometheus-{{ .id }}"
+  scrape_interval: 15s
+  honor_labels: true
+  metrics_path: '/federate'
+  params:
+    'match[]':
+      - '{job="openshift-state-metrics"}'
+  scheme: "https"
+  basic_auth:
+    username: 'internal'
+    password: "{{ .password }}"
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+    - targets:
+        - "{{ .hostname }}"
+      labels:
+        federated_job: "federated-prometheus-{{ .id }}"
   {{- end }}
   {{- range .Values.external_prometheus_hosts }}
-  - job_name: "external-prometheus-{{ .id }}"
-    scrape_interval: 15s
-    tls_config:
-      insecure_skip_verify: true
-    static_configs:
-      - targets:
-          - "{{ .hostname }}"
-        labels:
-          external_job: "external-prometheus-{{ .id }}"
+- job_name: "external-prometheus-{{ .id }}"
+  scrape_interval: 15s
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+    - targets:
+        - "{{ .hostname }}"
+      labels:
+        external_job: "external-prometheus-{{ .id }}"
   {{- end }}
 {{- end }}
 {{- if or .Values.federated_prometheus_hosts .Values.external_prometheus_hosts .Values.federate_openshift_monitoring.enabled }}


### PR DESCRIPTION
…gether

- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

<!-- Use this if merging should auto-close an issue, one issue per line -->
resolves #1142 

## Description

Our scrape config template had inconsistent indentations for different use cases, resulting in a malformed prometheus scrape config when a user tries to use multiple federation options together. This change fixes this.

## Testing Instructions

Create a pelorus with the following config:

```
kind: Pelorus
apiVersion: charts.pelorus.dora-metrics.io/v1alpha1
metadata:
  name: pelorus-devspaces
spec:
  federate_openshift_monitoring:
    enabled: true
    metrics_filter:
      # pull devspaces metrics we're interested in
      - '{namespace=~".*-devspaces",pod=~"workspace.+"}'
  external_prometheus_hosts:
    - id: 'prometheus-ldap'
      hostname: 'custom-prometheus-service.pelorus-operator.svc.cluster.local:9091'
  exporters:
    instances: []
  prometheus_storage: true
  prometheus_storage_pvc_capacity: 3Gi
  prometheus_storage_pvc_storageclass: gp2
  prometheus_retention_size: 2GB
```

Open the Prometheus dashboard and go to Status -> Targets. There should be two showing. In the broken state, we only get one of the two.
