### PR TITLE
Include repo url in committime

### DIFF
--- a/_test/prometheus/test.yaml
+++ b/_test/prometheus/test.yaml
@@ -106,12 +106,12 @@ tests:
     - labels: 'sdp:lead_time:by_app{app="basic-nginx"}'
       value: 972844
     - labels: 'sdp:lead_time:by_app{app="kenwilli-basic-spring-boot"}'
-      value: 1040483.6666666666
+      value: 1040483.6666666667
   - expr: sdp:lead_time:global
     eval_time: 1m
     exp_samples:
     - labels: 'sdp:lead_time:global'
-      value: 1006663.8333333333
+      value: 1006663.8333333334
   - expr: count(sdp:time_to_restore:by_issue)
     eval_time: 1m
     exp_samples:

--- a/_test/prometheus/test.yaml
+++ b/_test/prometheus/test.yaml
@@ -83,18 +83,22 @@ tests:
   - expr: sdp:lead_time:by_commit{app="basic-nginx"}
     eval_time: 1m
     exp_samples:
-    - labels: 'sdp:lead_time:by_commit{app="basic-nginx", commit="b4db23e0d91699165e92ea38ba03ac277c778397"}'
+    - labels: 'sdp:lead_time:by_commit{app="basic-nginx", commit="b4db23e0d91699165e92ea38ba03ac277c778397", image_sha="sha256:a344eb5673e7e3faf871e7375762f1869c823c957aa126ce8f52033395f2b358"}'
       value: 111
-    - labels: 'sdp:lead_time:by_commit{app="basic-nginx", commit="9421e2898111a38fd5b6a17d6c94c2e3569b5c2f"}'
+    - labels: 'sdp:lead_time:by_commit{app="basic-nginx", commit="9421e2898111a38fd5b6a17d6c94c2e3569b5c2f", image_sha="sha256:9e1348e33d416072d6301e5dc35e2c54b8dc95772b0a89ff2036fa79b368864d"}'
       value: 282
-    - labels: 'sdp:lead_time:by_commit{app="basic-nginx", commit="c8683ac2ae37cb9dd7c4c576747bf8f3d74c4f28"}'
+    - labels: 'sdp:lead_time:by_commit{app="basic-nginx", commit="c8683ac2ae37cb9dd7c4c576747bf8f3d74c4f28", image_sha="sha256:3131dfa239ec3db1e876ebea141b9d92627a432ca94949c7a6197d05261b0f84"}'
       value: 2918139
   # Ensure expected values for lead time for app 2
   - expr: sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot"}
     eval_time: 1m
     exp_samples:
-    - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d"}'
+    - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", image_sha="sha256:08ab5ef50c3fa51993e4d40b62533afe6619558aaba9e3a179c451b2676db7ed"}'
       value: 1028589
+    - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", image_sha="sha256:382947b77566babcc7c6c55f50cb17469c7d068bc4b0cfbdcd4b8b33e091d133"}'
+      value: 1047163
+    - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", image_sha="sha256:46332b417660900361f7185830a4eb6d5ddc7e3002944ba26ed260e83f415197"}'
+      value: 1045699
   # Check calculation of average lead time per application
   - expr: sdp:lead_time:by_app
     eval_time: 1m
@@ -102,12 +106,12 @@ tests:
     - labels: 'sdp:lead_time:by_app{app="basic-nginx"}'
       value: 972844
     - labels: 'sdp:lead_time:by_app{app="kenwilli-basic-spring-boot"}'
-      value: 1028589
+      value: 1040483.6666666666
   - expr: sdp:lead_time:global
     eval_time: 1m
     exp_samples:
     - labels: 'sdp:lead_time:global'
-      value: 1000716.5
+      value: 1006663.8333333333
   - expr: count(sdp:time_to_restore:by_issue)
     eval_time: 1m
     exp_samples:
@@ -136,12 +140,12 @@ tests:
     - labels: 'sdp:change_failure_rate:by_app{app="basic-nginx"}'
       value: .6666666666666666
     - labels: 'sdp:change_failure_rate:by_app{app="kenwilli-basic-spring-boot"}'
-      value: 1
+      value: .3333333333333333
   - expr: sdp:change_failure_rate:global
     eval_time: 1m
     exp_samples:
     - labels: 'sdp:change_failure_rate:global{}'
-      value: .8333333333333333
+      value: .5
 
 # Test app hierarchy filter in charts/pelorus/templates/dashboard-sdp-byapp.yaml
 - interval: 1m

--- a/_test/prometheus/test.yaml
+++ b/_test/prometheus/test.yaml
@@ -44,7 +44,7 @@ tests:
       - series: commit_timestamp{app="kenwilli-basic-spring-boot", commit="1a97f4bb5f05c9ef2e3791de01c02cb0610663e6", endpoint="http", exported_namespace="kenwilli-basic-spring-boot-build", image_sha="sha256:92e61fcec3cbc9a5f75793140b3d6996a864b326b0954dd7efd692cb9d3f45af", instance="10.130.0.85:8080", job="github-exporter", namespace="app-name-consistency", pod="github-exporter-3-pjmmj", service="github-exporter"}
         values: '1590532194'
       - series: commit_timestamp{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", endpoint="http", exported_namespace="kenwilli-basic-spring-boot-build", image_sha="sha256:08ab5ef50c3fa51993e4d40b62533afe6619558aaba9e3a179c451b2676db7ed", instance="10.130.0.85:8080", job="github-exporter", namespace="app-name-consistency", pod="github-exporter-3-pjmmj", service="github-exporter"}
-        values: '1590767500'
+        values: '1590750291'
       - series: commit_timestamp{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", endpoint="http", exported_namespace="kenwilli-basic-spring-boot-build", image_sha="sha256:46332b417660900361f7185830a4eb6d5ddc7e3002944ba26ed260e83f415197", instance="10.130.0.85:8080", job="github-exporter", namespace="app-name-consistency", pod="github-exporter-3-pjmmj", service="github-exporter"}
         values: '1590767500'
       - series: commit_timestamp{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", endpoint="http", exported_namespace="kenwilli-basic-spring-boot-build", image_sha="sha256:382947b77566babcc7c6c55f50cb17469c7d068bc4b0cfbdcd4b8b33e091d133", instance="10.130.0.85:8080", job="github-exporter", namespace="app-name-consistency", pod="github-exporter-3-pjmmj", service="github-exporter"}
@@ -94,7 +94,7 @@ tests:
     eval_time: 1m
     exp_samples:
     - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", image_sha="sha256:08ab5ef50c3fa51993e4d40b62533afe6619558aaba9e3a179c451b2676db7ed"}'
-      value: 1028589
+      value: 1045798
     - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", image_sha="sha256:382947b77566babcc7c6c55f50cb17469c7d068bc4b0cfbdcd4b8b33e091d133"}'
       value: 1047163
     - labels: 'sdp:lead_time:by_commit{app="kenwilli-basic-spring-boot", commit="ea67853d8f9b4f43400500f807d72cdfb5b0936d", image_sha="sha256:46332b417660900361f7185830a4eb6d5ddc7e3002944ba26ed260e83f415197"}'
@@ -106,12 +106,12 @@ tests:
     - labels: 'sdp:lead_time:by_app{app="basic-nginx"}'
       value: 972844
     - labels: 'sdp:lead_time:by_app{app="kenwilli-basic-spring-boot"}'
-      value: 1040483.6666666667
+      value: 1046220
   - expr: sdp:lead_time:global
     eval_time: 1m
     exp_samples:
     - labels: 'sdp:lead_time:global'
-      value: 1006663.8333333334
+      value: 1009532
   - expr: count(sdp:time_to_restore:by_issue)
     eval_time: 1m
     exp_samples:

--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.1
+version: 2.0.13-rc.2

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.1
-digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-11T19:08:27.806745358Z"
+  version: 2.0.13-rc.2
+digest: sha256:acffc6b35d891be294bdee3d59cf41ec462bf8433cdf72347c4bcf604ff14a99
+generated: "2024-07-25T20:08:20.392336664Z"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.1
+version: 2.0.13-rc.2
 
 dependencies:
   - name: exporters
-    version: 2.0.13-rc.1
+    version: 2.0.13-rc.2
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.1
+version: 2.0.13-rc.2

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/templates/prometheus-rules.yaml
+++ b/charts/pelorus/templates/prometheus-rules.yaml
@@ -12,7 +12,7 @@ spec:
 
     - record: sdp:lead_time:by_commit
       expr: >
-        min by (app, commit) (deploy_timestamp - on(app,image_sha) group_left(commit) commit_timestamp)
+        min by (app, commit, commit_link, image_sha) (deploy_timestamp - on(app,image_sha) group_left(commit, commit_link) commit_timestamp)
     - record: sdp:lead_time:by_app
       expr: >
         avg by (app) (sdp:lead_time:by_commit)

--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -63,6 +63,7 @@ class CommitMetric:
     The unix timestamp.
     In the future, this and commit_time should be combined.
     """
+    commit_link: Optional[str] = attr.field(default=None, kw_only=True)
 
     build_name: Optional[str] = attr.field(default=None, kw_only=True)
     build_config_name: Optional[str] = attr.field(default=None, kw_only=True)

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -88,6 +88,7 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
                 metric.commit_timestamp = (
                     timestamp.timestamp()
                 )  # hopefully they haven't provided a naive datetime
+                metric.commit_link = metric.repo_url
             except Exception:
                 logging.error(
                     "Failed processing commit time for build %s" % metric.build_name,

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -108,19 +108,20 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         commit_metric = GaugeMetricFamily(
             "commit_timestamp",
             "Commit timestamp",
-            labels=["namespace", "app", "commit", "image_sha"],
+            labels=["namespace", "app", "commit", "image_sha", "repo_url"],
         )
 
         commit_metrics = self.generate_metrics()
 
         for my_metric in commit_metrics:
             logging.debug(
-                "Collected commit_timestamp{ namespace=%s, app=%s, commit=%s, image_sha=%s } %s"
+                "Collected commit_timestamp{ namespace=%s, app=%s, commit=%s, image_sha=%s, repo_url=%s } %s"
                 % (
                     my_metric.namespace,
                     my_metric.name,
                     my_metric.commit_hash,
                     my_metric.image_hash,
+                    my_metric.repo_url,
                     str(float(my_metric.commit_timestamp)),
                 )
             )
@@ -130,6 +131,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                     format_app_name(my_metric.name),
                     my_metric.commit_hash,
                     my_metric.image_hash,
+                    my_metric.repo_url
                 ],
                 my_metric.commit_timestamp,
             )

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -131,7 +131,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                     format_app_name(my_metric.name),
                     my_metric.commit_hash,
                     my_metric.image_hash,
-                    my_metric.repo_url
+                    my_metric.repo_url,
                 ],
                 my_metric.commit_timestamp,
             )

--- a/exporters/committime/collector_bitbucket.py
+++ b/exporters/committime/collector_bitbucket.py
@@ -92,6 +92,8 @@ class Version1(APIVersion):
 
         # convert the time stamp to datetime and set in metric
         metric.commit_time = timestamp.isoformat()
+        # since the v1 api is deprecated, just set link to unknown
+        metric.commit_link = "unknown"
 
 
 class Version2(APIVersion):
@@ -119,6 +121,7 @@ class Version2(APIVersion):
         # API V2 has a human-readable time, which needs to be parsed.
         commit_time = api_response["date"]
         timestamp = parse_tz_aware(commit_time, _DATETIME_FORMAT)
+        commit_link = api_response["links"]["html"]
 
         logging.debug(
             "API v2 returned sha: %s, timestamp: %s (%s)",
@@ -130,6 +133,7 @@ class Version2(APIVersion):
         metric.commit_time = commit_time
         # set the timestamp after conversion
         metric.commit_timestamp = timestamp.timestamp()
+        metric.commit_link = commit_link
 
 
 _SUPPORTED_API_VERSIONS = (Version2(), Version1())

--- a/exporters/committime/collector_containerimage.py
+++ b/exporters/committime/collector_containerimage.py
@@ -317,7 +317,7 @@ class ContainerImageCommitCollector(AbstractCommitCollector):
                         commit_timestamp=pod.metadata.commit_timestamp,
                         image_hash=sha,
                     )
-                    metric.repo_url = pod.metadata.repo_url
+                    metric.commit_link = pod.metadata.repo_url
                     yield metric
 
         _cleanup_cache()

--- a/exporters/committime/collector_containerimage.py
+++ b/exporters/committime/collector_containerimage.py
@@ -182,6 +182,7 @@ def get_labels_from_image(sha_256: str, image_uri: str) -> Dict[str, str]:
     # We got the labels, so remove them from the potential
     # existence in the failures.
     _remove_from_skopeo_failure(sha_256)
+    logging.debug(f"Found the following labels for image {image_uri}: {labels}")
     return labels
 
 
@@ -230,11 +231,13 @@ def _set_commit_metadata(
     pod: ResourceField,
     date_label: str,
     hash_label: str,
+    repo_url_label: str,
     sha_256: str,
     date_format: str = None,
 ) -> None:
     with image_label_cache_lock:
         labels = image_label_cache.get(sha_256, None)
+        logging.debug(f"Got image labels for: {sha_256}")
         if labels and isinstance(labels, Tuple) and isinstance(labels[0], dict):
             pod.metadata.commit_hash = labels[0].get(hash_label)
             commit_time = labels[0].get(date_label)
@@ -251,6 +254,10 @@ def _set_commit_metadata(
                         ).timestamp()
                     except ValueError:
                         logging.debug(f"Can't get commit timestamp for sha: {sha_256}")
+            repo_url = labels[0].get(repo_url_label)
+            if not repo_url:
+                repo_url = "unknown"
+            pod.metadata.repo_url = repo_url
 
 
 @define(kw_only=True)
@@ -259,6 +266,7 @@ class ContainerImageCommitCollector(AbstractCommitCollector):
 
     date_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["commit_time"]
     hash_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["commit_hash"]
+    repo_url_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["repo_url"]
 
     def get_commit_time(self, metric) -> Optional[CommitMetric]:
         return super().get_commit_time(metric)
@@ -296,6 +304,7 @@ class ContainerImageCommitCollector(AbstractCommitCollector):
                     pod,
                     self.date_annotation_name,
                     self.hash_annotation_name,
+                    self.repo_url_annotation_name,
                     sha,
                     self.date_format,
                 )
@@ -308,6 +317,7 @@ class ContainerImageCommitCollector(AbstractCommitCollector):
                         commit_timestamp=pod.metadata.commit_timestamp,
                         image_hash=sha,
                     )
+                    metric.repo_url = pod.metadata.repo_url
                     yield metric
 
         _cleanup_cache()

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -83,6 +83,7 @@ class GiteaCommitCollector(AbstractCommitCollector):
 
                 logging.debug("metric.commit_time %s", commit_time)
                 metric.commit_timestamp = commit_time.timestamp()
+                metric.commit_link = commit["html_url"]
             except Exception:
                 logging.error(
                     "Failed processing commit time for build %s" % metric.build_name,

--- a/exporters/committime/collector_github.py
+++ b/exporters/committime/collector_github.py
@@ -69,6 +69,8 @@ class GitHubCommitCollector(AbstractCommitCollector):
             try:
                 metric.commit_time = commit["commit"]["committer"]["date"]
                 metric.commit_timestamp = parse_datetime(metric.commit_time).timestamp()
+                metric.commit_link = commit["html_url"]
+                logging.debug(f"Set all github commit metrics: {metric}")
             except Exception:
                 logging.error(
                     "Failed processing commit time for build %s" % metric.build_name,

--- a/exporters/committime/collector_gitlab.py
+++ b/exporters/committime/collector_gitlab.py
@@ -116,6 +116,7 @@ class GitLabCommitCollector(AbstractCommitCollector):
             metric.commit_timestamp = parse_tz_aware(
                 commit_time_str, format=_DATETIME_FORMAT
             ).timestamp()
+            metric.commit_link = commit.web_url
         except Exception:
             logging.error(
                 "Failed processing commit time for build %s" % metric.build_name,

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -48,13 +48,13 @@ def expected_commits() -> list[CommitMetricEssentials]:
             commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
             image_hash="sha256:c1282f65b5c327db4dcc6cdfb27e91338bd625d119d9ae769318f089d82e35e2",
         ),
-        CommitMetricEssentials(
-            commit_timestamp=1619381788.0,
-            namespace="basic-nginx-build",
-            name="basic-nginx",
-            commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
-            image_hash="sha256:4a20c8cfa48af3a938462e9cd7bfa0b16abfbc6ba16f0999f3931c79b1130e4b",
-        ),
+        # CommitMetricEssentials(
+        #     commit_timestamp=1619381788.0,
+        #     namespace="basic-nginx-build",
+        #     name="basic-nginx",
+        #     commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
+        #     image_hash="sha256:4a20c8cfa48af3a938462e9cd7bfa0b16abfbc6ba16f0999f3931c79b1130e4b",
+        # ),
         CommitMetricEssentials(
             commit_timestamp=1620401174.0,
             namespace="basic-nginx-build",

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -48,13 +48,13 @@ def expected_commits() -> list[CommitMetricEssentials]:
             commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
             image_hash="sha256:c1282f65b5c327db4dcc6cdfb27e91338bd625d119d9ae769318f089d82e35e2",
         ),
-        # CommitMetricEssentials(
-        #     commit_timestamp=1619381788.0,
-        #     namespace="basic-nginx-build",
-        #     name="basic-nginx",
-        #     commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
-        #     image_hash="sha256:4a20c8cfa48af3a938462e9cd7bfa0b16abfbc6ba16f0999f3931c79b1130e4b",
-        # ),
+        CommitMetricEssentials(
+            commit_timestamp=1619381788.0,
+            namespace="basic-nginx-build",
+            name="basic-nginx",
+            commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
+            image_hash="sha256:c1282f65b5c327db4dcc6cdfb27e91338bd625d119d9ae769318f089d82e35e2",
+        ),
         CommitMetricEssentials(
             commit_timestamp=1620401174.0,
             namespace="basic-nginx-build",

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.10-rc.1
+VERSION ?= 0.0.10-rc.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
-    createdAt: "2024-07-25T20:08:21Z"
+    createdAt: "2024-08-05T20:19:51Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -211,6 +211,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings
@@ -241,15 +250,6 @@ spec:
           - route.openshift.io
           resources:
           - routes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
-    createdAt: "2024-07-11T19:08:34Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
+    createdAt: "2024-07-25T20:08:21Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -58,7 +58,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.10-rc.1
+  name: pelorus-operator.v0.0.10-rc.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -211,6 +211,19 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
           - image.openshift.io
           resources:
           - imagestreams
@@ -237,27 +250,6 @@ spec:
           - secrets
           - serviceaccounts
           - services
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - integreatly.org
-          resources:
-          - grafanadashboards
-          - grafanadatasources
-          - grafanas
           verbs:
           - '*'
         - apiGroups:
@@ -393,7 +385,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
+                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -495,7 +487,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.10-rc.1
+  version: 0.0.10-rc.2
   replaces: pelorus-operator.v0.0.9
   skips:
     - pelorus-operator.v0.0.9

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.10-rc.1
+  newTag: 0.0.10-rc.2

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,15 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
+- verbs:
+  - "*"
+  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "rolebindings"
@@ -85,14 +94,5 @@ rules:
   - "route.openshift.io"
   resources:
   - "routes"
-- verbs:
-  - "*"
-  apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,19 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "rolebindings"
+  - "roles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "apps.openshift.io"
+  resources:
+  - "deploymentconfigs"
+- verbs:
+  - "*"
+  apiGroups:
   - "image.openshift.io"
   resources:
   - "imagestreams"
@@ -81,26 +94,5 @@ rules:
   - "secrets"
   - "serviceaccounts"
   - "services"
-- verbs:
-  - "*"
-  apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  - "rolebindings"
-  - "roles"
-- verbs:
-  - "*"
-  apiGroups:
-  - "apps.openshift.io"
-  resources:
-  - "deploymentconfigs"
-- verbs:
-  - "*"
-  apiGroups:
-  - "integreatly.org"
-  resources:
-  - "grafanadashboards"
-  - "grafanadatasources"
-  - "grafanas"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.1
-digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-11T19:08:28.036277921Z"
+  version: 2.0.13-rc.2
+digest: sha256:acffc6b35d891be294bdee3d59cf41ec462bf8433cdf72347c4bcf604ff14a99
+generated: "2024-07-25T20:08:20.628605315Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.2
 digest: sha256:acffc6b35d891be294bdee3d59cf41ec462bf8433cdf72347c4bcf604ff14a99
-generated: "2024-07-25T20:08:20.628605315Z"
+generated: "2024-08-05T20:19:50.521060343Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.1
+  version: 2.0.13-rc.2
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.13-rc.1
+version: 2.0.13-rc.2

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.1
+version: 2.0.13-rc.2

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.1" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-rules.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-rules.yaml
@@ -12,7 +12,7 @@ spec:
 
     - record: sdp:lead_time:by_commit
       expr: >
-        min by (app, commit) (deploy_timestamp - on(app,image_sha) group_left(commit) commit_timestamp)
+        min by (app, commit, commit_link, image_sha) (deploy_timestamp - on(app,image_sha) group_left(commit, commit_link) commit_timestamp)
     - record: sdp:lead_time:by_app
       expr: >
         avg by (app) (sdp:lead_time:by_commit)

--- a/pelorus.code-workspace
+++ b/pelorus.code-workspace
@@ -3,9 +3,6 @@
 		{
 			"name": "pelorus",
 			"path": "/projects/pelorus"
-		},
-		{
-			"path": "../pelorus-api"
 		}
 	],
 	"extensions": {


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

resolves #1089 

## Description

This change adds a new `repo_url` label to the committime metric across all providers. It ensures that when we capture a commit time, we also capture the source code repo URL for that commit. This will help us to show users where their metrics are coming from and help users validate the metrics we collect when there are questions about how we're getting our data.

## Testing Instructions

Deploy the operator from the PR builds above.

Set up a pelorus instance with the following comittime exporter types:

```
      - enabled: true
        app_name: committime-image
        exporter_type: committime
        extraEnv:
        - name: PROVIDER
          value: containerimage
      - enabled: true
        app_name: committime-git
        exporter_type: committime
        extraEnv:
        - name: PROVIDER
          value: git

```

Generate data by running through the examples here: https://pelorus.readthedocs.io/en/v2.0.12/GettingStarted/configuration/ExporterCommittime/#example-workflow-for-an-openshift-binary-build

Check in Prometheus for `commit_timestamp` entries. You should now see metrics that look like this:

```
commit_timestamp{app="/pelorus-api/", commit="fefa7416e2c3ee424f53dbdbd46b7b758da4eb3d", container="committime-exporter", endpoint="http", exported_namespace="pelorus-api", image_sha="sha256:90f5978f8aa4303aacb4eb997a7e15371222515bc67300db1d5ab13b1296b335", instance="10.128.1.56:8080", job="committime-exporter", namespace="test-pelorus-operator", pod="committime-exporter-1-v2ktw", repo_url="https://github.com/etsauer/pelorus-api", service="committime-exporter"} | 1717780394
-- | --
commit_timestamp{app="/python-binary-build/", commit="7810f2a85d5c89cb4b17e9a3208a311af65338d8", container="committime-exporter-git", endpoint="http", exported_namespace="binary-build", image_sha="sha256:71a1f49ff412b13ef2d3e4663d890892ff99b66fe841679e26c2350ccd2bd5f5", instance="10.128.1.68:8080", job="committime-exporter-git", namespace="test-pelorus-operator", pod="committime-exporter-git-1-9jjhw", repo_url="http://github.com/dora-metrics/pelorus", service="committime-exporter-git"} | 1654810223

```