### PR TITLE
Upgrade grafana and prometheus versions to latest available

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.2
+version: 2.0.13-rc.3

--- a/charts/operators/templates/grafana-subscription.yaml
+++ b/charts/operators/templates/grafana-subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: grafana-operator
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Manual
   name: grafana-operator
   source: community-operators

--- a/charts/operators/values.yaml
+++ b/charts/operators/values.yaml
@@ -1,3 +1,3 @@
 ---
 grafana_subscription_version: 5.12.0
-prometheus_subscription_version: 4.10.0
+prometheus_subscription_version: 0.56.3

--- a/charts/operators/values.yaml
+++ b/charts/operators/values.yaml
@@ -1,3 +1,3 @@
 ---
-grafana_subscription_version: 4.8.0
-prometheus_subscription_version: 0.47.0
+grafana_subscription_version: 5.12.0
+prometheus_subscription_version: 4.10.0

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.2
-digest: sha256:acffc6b35d891be294bdee3d59cf41ec462bf8433cdf72347c4bcf604ff14a99
-generated: "2024-07-25T20:08:20.392336664Z"
+  version: 2.0.13-rc.3
+digest: sha256:742d458f384de076ddbb4a0cf2d4b4127ef1365c319212c7d64a315157fd94f5
+generated: "2024-09-05T13:30:14.412659258Z"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.2
+version: 2.0.13-rc.3
 
 dependencies:
   - name: exporters
-    version: 2.0.13-rc.2
+    version: 2.0.13-rc.3
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.2
+version: 2.0.13-rc.3

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
               {{- end }}
             {{- end }}
 

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/templates/prometheus-service.yaml
+++ b/charts/pelorus/templates/prometheus-service.yaml
@@ -18,7 +18,7 @@ spec:
     protocol: TCP
     targetPort: web-tls
   selector:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: prometheus-pelorus
   sessionAffinity: ClientIP
   sessionAffinityConfig:

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.10-rc.2
+VERSION ?= 0.0.10-rc.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
-    createdAt: "2024-08-05T20:19:51Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
+    createdAt: "2024-09-05T13:30:15Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -58,7 +58,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.10-rc.2
+  name: pelorus-operator.v0.0.10-rc.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -385,7 +385,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
+                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -487,7 +487,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.10-rc.2
+  version: 0.0.10-rc.3
   replaces: pelorus-operator.v0.0.9
   skips:
     - pelorus-operator.v0.0.9

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
-    createdAt: "2024-09-05T14:52:24Z"
+    createdAt: "2024-09-05T18:53:43Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
-    createdAt: "2024-09-05T13:30:15Z"
+    createdAt: "2024-09-05T14:52:24Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -211,15 +211,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
-          verbs:
-          - '*'
-        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings
@@ -250,6 +241,15 @@ spec:
           - route.openshift.io
           resources:
           - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/bundle/metadata/properties.yaml
+++ b/pelorus-operator/bundle/metadata/properties.yaml
@@ -2,8 +2,8 @@ dependencies:
 - type: olm.package
   value:
     packageName: prometheus
-    version: "0.47.0"
+    version: "4.10.0"
 - type: olm.package
   value:
     packageName: grafana-operator
-    version: "4.8.0"
+    version: "5.12.0"

--- a/pelorus-operator/bundle/metadata/properties.yaml
+++ b/pelorus-operator/bundle/metadata/properties.yaml
@@ -2,7 +2,7 @@ dependencies:
 - type: olm.package
   value:
     packageName: prometheus
-    version: "4.10.0"
+    version: "0.56.3"
 - type: olm.package
   value:
     packageName: grafana-operator

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.10-rc.2
+  newTag: 0.0.10-rc.3

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.2
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,15 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
-- verbs:
-  - "*"
-  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "rolebindings"
@@ -94,5 +85,14 @@ rules:
   - "route.openshift.io"
   resources:
   - "routes"
+- verbs:
+  - "*"
+  apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.3
 digest: sha256:742d458f384de076ddbb4a0cf2d4b4127ef1365c319212c7d64a315157fd94f5
-generated: "2024-09-05T14:52:23.54355078Z"
+generated: "2024-09-05T18:53:43.104094598Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.3
 digest: sha256:742d458f384de076ddbb4a0cf2d4b4127ef1365c319212c7d64a315157fd94f5
-generated: "2024-09-05T13:30:14.726034742Z"
+generated: "2024-09-05T14:52:23.54355078Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.2
-digest: sha256:acffc6b35d891be294bdee3d59cf41ec462bf8433cdf72347c4bcf604ff14a99
-generated: "2024-08-05T20:19:50.521060343Z"
+  version: 2.0.13-rc.3
+digest: sha256:742d458f384de076ddbb4a0cf2d4b4127ef1365c319212c7d64a315157fd94f5
+generated: "2024-09-05T13:30:14.726034742Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.2
+  version: 2.0.13-rc.3
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.13-rc.2
+version: 2.0.13-rc.3

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.2
+version: 2.0.13-rc.3

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
               {{- end }}
             {{- end }}
 

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.2" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-service.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-service.yaml
@@ -18,7 +18,7 @@ spec:
     protocol: TCP
     targetPort: web-tls
   selector:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: prometheus-pelorus
   sessionAffinity: ClientIP
   sessionAffinityConfig:

--- a/scripts/pelorus-operator-patches/bundle-patches/01_prometheus_grafana_dependencies.diff
+++ b/scripts/pelorus-operator-patches/bundle-patches/01_prometheus_grafana_dependencies.diff
@@ -5,9 +5,9 @@
 +- type: olm.package
 +  value:
 +    packageName: prometheus
-+    version: "0.47.0"
++    version: "0.56.3"
 +- type: olm.package
 +  value:
 +    packageName: grafana-operator
-+    version: "4.8.0"
++    version: "5.12.0"
 


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

<!-- Use this if merging should auto-close an issue, one issue per line -->
resolves #1156 

## Description

This change upgrades the prometheus and grafana operator dependencies to the latest versions currently available in OperatorHub:

* Prometheus Operator v4.10.0
* Grafana Operator v5.12.0

## Testing Instructions

1. Deploy PR build of the operator, make sure install goes well. 
2. Need to find some way to test upgrades in an instance that contains data