### PR TITLE
Convert exporters to use kubernetes deployments instead of openshift …

### DIFF
--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -87,7 +87,7 @@ jobs:
 
           sed -i "s,$DEFAULT_OPERATOR_IMAGE,$TEST_OPERATOR_IMAGE,g" bundle/manifests/pelorus-operator.clusterserviceversion.yaml
           sed -i "s,$DEFAULT_EXPORTER_IMAGE,$TEST_EXPORTER_IMAGE,g" helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
-          sed -i "s,$DEFAULT_EXPORTER_IMAGE,$TEST_EXPORTER_IMAGE,g" helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+          sed -i "s,$DEFAULT_EXPORTER_IMAGE,$TEST_EXPORTER_IMAGE,g" helm-charts/pelorus/charts/exporters/templates/_deployment.yaml
           sed -i "s,$CURRENT_OPERATOR_VERSION,$TEST_VERSION,g" Makefile
           sed -i "s,pelorus-operator,rc-pelorus-operator,g" Makefile
           find . -type f | xargs sed -i "s,$CURRENT_OPERATOR_VERSION,$CURRENT_OPERATOR_VERSION-$TEST_VERSION,g"
@@ -95,7 +95,7 @@ jobs:
 
           grep "$TEST_OPERATOR_IMAGE" bundle/manifests/pelorus-operator.clusterserviceversion.yaml
           grep "$TEST_EXPORTER_IMAGE" helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
-          grep "$TEST_VERSION" helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+          grep "$TEST_VERSION" helm-charts/pelorus/charts/exporters/templates/_deployment.yaml
           grep "$TEST_VERSION" Makefile
           grep rc-pelorus-operator Makefile
 

--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.3
+version: 2.0.13-rc.4

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.3
-digest: sha256:742d458f384de076ddbb4a0cf2d4b4127ef1365c319212c7d64a315157fd94f5
-generated: "2024-09-05T13:30:14.412659258Z"
+  version: 2.0.13-rc.4
+digest: sha256:9044a4123b267fb9c42945ced5af31fcc02d8ff2000057662fbb40f72b027884
+generated: "2024-09-09T15:49:18.189990808Z"

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.3
+version: 2.0.13-rc.4
 
 dependencies:
   - name: exporters
-    version: 2.0.13-rc.3
+    version: 2.0.13-rc.4
     repository: file://./charts/exporters

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.3
+version: 2.0.13-rc.4

--- a/charts/pelorus/charts/exporters/templates/_deployment.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deployment.yaml
@@ -1,7 +1,7 @@
 {{- define "exporters.deploymentconfig" }}
 ---
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: {{ .app_name }}
@@ -9,20 +9,15 @@ metadata:
   name: {{ .app_name }}
 spec:
   replicas: 1
-  revisionHistoryLimit: 10
   selector:
-    app.kubernetes.io/name: {{ .app_name }}
-    app: {{ .app_name }}
-    deploymentconfig: {{ .app_name }}
-  strategy:
-    type: Rolling
+    matchLabels:
+      app.kubernetes.io/name: {{ .app_name }}
+      app: {{ .app_name }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ .app_name }}
         app: {{ .app_name }}
-        deploymentconfig: {{ .app_name }}
-        application: {{ .app_name }}
         pelorus.dora-metrics.io/exporter-type: {{ .exporter_type | default "generic-exporter" }}
     spec:
       serviceAccount: pelorus-exporter
@@ -67,7 +62,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.4" }}
               {{- end }}
             {{- end }}
 
@@ -87,20 +82,4 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
-  triggers:
-  - type: ConfigChange
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - {{ .app_name }}
-      from:
-        kind: ImageStreamTag
-        {{- if or .source_ref .source_url }}
-        name: {{ .app_name }}:latest
-        {{- else }}
-        # default is an internal registry tag and must match the default from
-        # _imagestream_from_image.yaml
-        name: {{ .app_name }}:{{ .image_tag | default "stable" }}
-        {{- end }}
-    type: ImageChange
 {{- end }}

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.4" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -593,7 +593,7 @@ export TEST_EXPORTER_IMAGE="$REPOSITORY/rc-pelorus-exporter:{{ .image_tag | defa
 
 sed -i "s,$DEFAULT_OPERATOR_IMAGE,$TEST_OPERATOR_IMAGE,g" bundle/manifests/pelorus-operator.clusterserviceversion.yaml
 sed -i "s,$DEFAULT_EXPORTER_IMAGE,$TEST_EXPORTER_IMAGE,g" helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
-sed -i "s,$DEFAULT_EXPORTER_IMAGE,$TEST_EXPORTER_IMAGE,g" helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+sed -i "s,$DEFAULT_EXPORTER_IMAGE,$TEST_EXPORTER_IMAGE,g" helm-charts/pelorus/charts/exporters/templates/_deployment.yaml
 sed -i "s,$CURRENT_OPERATOR_VERSION,$TEST_VERSION,g" Makefile
 sed -i "s,pelorus-operator,rc-pelorus-operator,g" Makefile
 find . -type f | xargs sed -i "s,$CURRENT_OPERATOR_VERSION,$CURRENT_OPERATOR_VERSION-$TEST_VERSION,g"

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.10-rc.3
+VERSION ?= 0.0.10-rc.4
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
-    createdAt: "2024-09-05T18:53:43Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.4
+    createdAt: "2024-09-09T15:49:19Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -58,7 +58,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/dora-metrics/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.10-rc.3
+  name: pelorus-operator.v0.0.10-rc.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -211,6 +211,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings
@@ -218,9 +227,9 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - apps.openshift.io
+          - apps
           resources:
-          - deploymentconfigs
+          - deployments
           verbs:
           - '*'
         - apiGroups:
@@ -241,15 +250,6 @@ spec:
           - route.openshift.io
           resources:
           - routes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
           verbs:
           - '*'
         - apiGroups:
@@ -385,7 +385,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
+                image: quay.io/pelorus/pelorus-operator:0.0.10-rc.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -487,7 +487,7 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.10-rc.3
+  version: 0.0.10-rc.4
   replaces: pelorus-operator.v0.0.9
   skips:
     - pelorus-operator.v0.0.9

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.10-rc.3
+  newTag: 0.0.10-rc.4

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.3
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.4
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,15 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
+- verbs:
+  - "*"
+  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "rolebindings"
@@ -62,9 +71,9 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "apps.openshift.io"
+  - "apps"
   resources:
-  - "deploymentconfigs"
+  - "deployments"
 - verbs:
   - "*"
   apiGroups:
@@ -85,14 +94,5 @@ rules:
   - "route.openshift.io"
   resources:
   - "routes"
-- verbs:
-  - "*"
-  apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.3
-digest: sha256:742d458f384de076ddbb4a0cf2d4b4127ef1365c319212c7d64a315157fd94f5
-generated: "2024-09-05T18:53:43.104094598Z"
+  version: 2.0.13-rc.4
+digest: sha256:9044a4123b267fb9c42945ced5af31fcc02d8ff2000057662fbb40f72b027884
+generated: "2024-09-09T15:49:18.510009719Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./charts/exporters
-  version: 2.0.13-rc.3
+  version: 2.0.13-rc.4
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.13-rc.3
+version: 2.0.13-rc.4

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.13-rc.3
+version: 2.0.13-rc.4

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deployment.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deployment.yaml
@@ -1,7 +1,7 @@
 {{- define "exporters.deploymentconfig" }}
 ---
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: {{ .app_name }}
@@ -9,20 +9,15 @@ metadata:
   name: {{ .app_name }}
 spec:
   replicas: 1
-  revisionHistoryLimit: 10
   selector:
-    app.kubernetes.io/name: {{ .app_name }}
-    app: {{ .app_name }}
-    deploymentconfig: {{ .app_name }}
-  strategy:
-    type: Rolling
+    matchLabels:
+      app.kubernetes.io/name: {{ .app_name }}
+      app: {{ .app_name }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ .app_name }}
         app: {{ .app_name }}
-        deploymentconfig: {{ .app_name }}
-        application: {{ .app_name }}
         pelorus.dora-metrics.io/exporter-type: {{ .exporter_type | default "generic-exporter" }}
     spec:
       serviceAccount: pelorus-exporter
@@ -67,7 +62,7 @@ spec:
               value: {{ .image_name }}:{{ .image_tag | default "latest" }}
                 {{- end }}
               {{- else }}
-              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
+              value: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.4" }}
               {{- end }}
             {{- end }}
 
@@ -87,20 +82,4 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
-  triggers:
-  - type: ConfigChange
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - {{ .app_name }}
-      from:
-        kind: ImageStreamTag
-        {{- if or .source_ref .source_url }}
-        name: {{ .app_name }}:latest
-        {{- else }}
-        # default is an internal registry tag and must match the default from
-        # _imagestream_from_image.yaml
-        name: {{ .app_name }}:{{ .image_tag | default "stable" }}
-        {{- end }}
-    type: ImageChange
 {{- end }}

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "latest" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.3" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.13-rc.4" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/scripts/chart-test.sh
+++ b/scripts/chart-test.sh
@@ -38,8 +38,8 @@ fi
 ct lint --remote "$REMOTE" --config ct.yaml || exit 1
 rm -f charts/pelorus/charts/*.tgz
 
-if ! grep "default \"v$CURRENT_CHART_VERSION\"" charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml &> /dev/null; then
-  echo "ERROR: Version in charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml differs!"
+if ! grep "default \"v$CURRENT_CHART_VERSION\"" charts/pelorus/charts/exporters/templates/_deployment.yaml &> /dev/null; then
+  echo "ERROR: Version in charts/pelorus/charts/exporters/templates/_deployment.yaml differs!"
   echo "$HELP_MESSAGE"
   exit 1
 fi

--- a/scripts/update_projects_version.py
+++ b/scripts/update_projects_version.py
@@ -56,7 +56,7 @@ CHARTS_FILES_TO_UPDATE = {
     PELORUS_CHARTS_FOLDER / "Chart.yaml": 2,
     ROOT / "charts/operators/Chart.yaml": 1,
     PELORUS_EXPORTERS_FOLDER / "Chart.yaml": 1,
-    PELORUS_EXPORTERS_FOLDER / "templates/_deploymentconfig.yaml": 1,
+    PELORUS_EXPORTERS_FOLDER / "templates/_deployment.yaml": 1,
     PELORUS_EXPORTERS_FOLDER / "templates/_imagestream_from_image.yaml": 1,
 }
 DEVELOPMENT_FILE = ROOT / "docs/Development.md"


### PR DESCRIPTION
…deploymentconfigs, which are deprecated

- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues

resolves #1147 

## Description

* Converted exporter helm chart to deploy using kubnetes Deployments instead of depcrecated OpenShift DeploymentConfigs
* Renamed the _deploymentconfig.yaml file to _deployment.yaml
* Updated helper scripts with changed file name
 
## Testing Instructions

Install operator from PR build, and create a test pelorus CR instance. See that exporters deploy successfully, and that they show up on the "Deployments" page in the web console instead of "DeploymentConfigs".
